### PR TITLE
Add high-priority architectural fixes

### DIFF
--- a/src/embeddings/jina.ts
+++ b/src/embeddings/jina.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
+import { fetchWithRetry } from './retry.js';
 
 /**
  * Jina AI embedding backend
@@ -29,7 +30,7 @@ export class JinaBackend implements EmbeddingBackend {
   }
 
   async embed(text: string): Promise<number[]> {
-    const response = await fetch(this.baseUrl, {
+    const response = await fetchWithRetry(this.baseUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -51,7 +52,7 @@ export class JinaBackend implements EmbeddingBackend {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
-    const response = await fetch(this.baseUrl, {
+    const response = await fetchWithRetry(this.baseUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
+import { fetchWithRetry } from './retry.js';
 
 /**
  * Ollama embedding backend
@@ -18,7 +19,7 @@ export class OllamaBackend implements EmbeddingBackend {
   async initialize(): Promise<void> {
     // Test connection
     try {
-      const response = await fetch(`${this.baseUrl}/api/tags`);
+      const response = await fetchWithRetry(`${this.baseUrl}/api/tags`, {});
       if (!response.ok) {
         throw new Error(`Ollama server returned ${response.status}`);
       }
@@ -28,7 +29,7 @@ export class OllamaBackend implements EmbeddingBackend {
   }
 
   async embed(text: string): Promise<number[]> {
-    const response = await fetch(`${this.baseUrl}/api/embeddings`, {
+    const response = await fetchWithRetry(`${this.baseUrl}/api/embeddings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/embeddings/openai.ts
+++ b/src/embeddings/openai.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
+import { fetchWithRetry } from './retry.js';
 
 const OPENAI_EMBEDDING_MODELS: Record<string, number> = {
   'text-embedding-3-small': 1536,
@@ -27,7 +28,7 @@ export class OpenAIBackend implements EmbeddingBackend {
 
   async initialize(): Promise<void> {
     // Test the API key with a simple request
-    const response = await fetch(`${this.baseUrl}/models`, {
+    const response = await fetchWithRetry(`${this.baseUrl}/models`, {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
       },
@@ -44,7 +45,7 @@ export class OpenAIBackend implements EmbeddingBackend {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
-    const response = await fetch(`${this.baseUrl}/embeddings`, {
+    const response = await fetchWithRetry(`${this.baseUrl}/embeddings`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.apiKey}`,

--- a/src/embeddings/retry.ts
+++ b/src/embeddings/retry.ts
@@ -1,0 +1,94 @@
+/**
+ * Retry configuration options
+ */
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+const DEFAULT_OPTIONS: Required<RetryOptions> = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 10000,
+};
+
+/**
+ * Sleep for a given number of milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check if an error is retryable (network errors, rate limits, server errors)
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    // Retry on network errors
+    if (message.includes('fetch') || message.includes('network') || message.includes('econnrefused')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a response status is retryable
+ */
+function isRetryableStatus(status: number): boolean {
+  // Retry on rate limits (429), server errors (5xx), and some specific cases
+  return status === 429 || status === 408 || (status >= 500 && status < 600);
+}
+
+/**
+ * Execute a fetch request with exponential backoff retry
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  retryOptions?: RetryOptions
+): Promise<Response> {
+  const opts = { ...DEFAULT_OPTIONS, ...retryOptions };
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+
+      // If response is ok or non-retryable error, return it
+      if (response.ok || !isRetryableStatus(response.status)) {
+        return response;
+      }
+
+      // Retryable status code
+      if (attempt < opts.maxRetries) {
+        const delay = Math.min(opts.baseDelayMs * Math.pow(2, attempt), opts.maxDelayMs);
+        console.error(
+          `[lance-context] Request failed with status ${response.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      // Last attempt, return the response even if it's an error
+      return response;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      if (attempt < opts.maxRetries && isRetryableError(error)) {
+        const delay = Math.min(opts.baseDelayMs * Math.pow(2, attempt), opts.maxDelayMs);
+        console.error(
+          `[lance-context] Request failed: ${lastError.message}, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      throw lastError;
+    }
+  }
+
+  throw lastError || new Error('Request failed after retries');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,18 @@ import { CodeIndexer } from './search/indexer.js';
 
 const PROJECT_PATH = process.env.LANCE_CONTEXT_PROJECT || process.cwd();
 
-let indexer: CodeIndexer | null = null;
+let indexerPromise: Promise<CodeIndexer> | null = null;
 
 async function getIndexer(): Promise<CodeIndexer> {
-  if (!indexer) {
-    const backend = await createEmbeddingBackend();
-    indexer = new CodeIndexer(PROJECT_PATH, backend);
-    await indexer.initialize();
+  if (!indexerPromise) {
+    indexerPromise = (async () => {
+      const backend = await createEmbeddingBackend();
+      const idx = new CodeIndexer(PROJECT_PATH, backend);
+      await idx.initialize();
+      return idx;
+    })();
   }
-  return indexer;
+  return indexerPromise;
 }
 
 const server = new Server(


### PR DESCRIPTION
## Summary

- Fix race condition in singleton indexer initialization using promise caching
- Add embedding dimension validation to detect backend mismatches and force re-index
- Add retry logic with exponential backoff for all embedding API calls

## Details

### Race Condition Fix
Changed `getIndexer()` from storing a nullable `CodeIndexer` to caching the initialization `Promise`. Multiple concurrent MCP tool calls now await the same promise instead of triggering parallel initialization.

### Embedding Dimension Validation
- Added `embeddingDimensions` to index metadata
- On index load, checks if stored dimensions match current backend
- Automatically forces full re-index on mismatch with warning message

### Retry Logic
- New `fetchWithRetry()` utility with exponential backoff (3 retries, 1-10s delays)
- Retries on: HTTP 429 (rate limit), 408 (timeout), 5xx errors, network failures
- Applied to all API calls in OpenAI, Jina, and Ollama backends

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 18 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.ai/code)