### PR TITLE
Add search_similar tool for finding semantically similar code

### DIFF
--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -10,6 +10,7 @@ import type { LanceContextConfig } from '../config.js';
 export type CommandName =
   | 'index_codebase'
   | 'search_code'
+  | 'search_similar'
   | 'get_index_status'
   | 'clear_index'
   | 'get_project_instructions';
@@ -44,6 +45,7 @@ export interface DashboardStateEvents {
 const COMMAND_LABELS: Record<CommandName, string> = {
   index_codebase: 'Index Codebase',
   search_code: 'Search Code',
+  search_similar: 'Search Similar',
   get_index_status: 'Get Status',
   clear_index: 'Clear Index',
   get_project_instructions: 'Get Instructions',
@@ -219,6 +221,7 @@ export class DashboardStateManager extends EventEmitter {
 
     const allCommands: CommandName[] = [
       'search_code',
+      'search_similar',
       'index_codebase',
       'get_index_status',
       'clear_index',


### PR DESCRIPTION
## Summary
Adds a new `search_similar` MCP tool that finds code semantically similar to a given code snippet or file location. This is a unique capability that Serena/LSP tools cannot provide.

## Use Cases
- Finding duplicate/similar logic for refactoring opportunities
- Understanding implementation patterns across the codebase
- Discovering related code when exploring unfamiliar codebases

## API
```typescript
search_similar({
  // Option 1: Reference existing code by location
  filepath?: string,
  startLine?: number,
  endLine?: number,
  
  // Option 2: Provide code snippet directly
  code?: string,
  
  // Common options
  limit?: number,        // default 10
  threshold?: number,    // minimum similarity score 0-1
  excludeSelf?: boolean  // exclude source chunk (default: true)
})
```

## Changes
- Added `SearchSimilarOptions` and `SimilarCodeResult` interfaces
- Added `searchSimilar()` method to `CodeIndexer`
- Added `search_similar` tool definition and handler
- Added `search_similar` to dashboard command tracking
- Added 4 new tests for the feature

## Test plan
- [x] All 302 tests pass (4 new tests)
- [x] Type-check passes
- [x] Lint passes (warnings only)

Closes lance-context-ro0

🤖 Generated with [Claude Code](https://claude.com/claude-code)