### PR TITLE
Add path and language filtering to search_code tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,13 @@
     "": {
       "name": "lance-context",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "@lancedb/lancedb": "^0.22.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "glob": "^13.0.0",
+        "minimatch": "^10.1.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -5128,7 +5130,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@lancedb/lancedb": "^0.22.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "glob": "^13.0.0",
+    "minimatch": "^10.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'number',
               description: 'Maximum number of results (default: 10)',
             },
+            pathPattern: {
+              type: 'string',
+              description:
+                "Glob pattern to filter results by file path (e.g., 'src/**/*.ts', '!**/*.test.ts')",
+            },
+            languages: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                "Filter results to specific languages (e.g., ['typescript', 'javascript'])",
+            },
           },
           required: ['query'],
         },
@@ -300,8 +311,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!query) {
           throw new Error('query is required');
         }
-        const limit = isNumber(args?.limit) ? args.limit : 10;
-        const results = await idx.search(query, limit);
+        const results = await idx.search({
+          query,
+          limit: isNumber(args?.limit) ? args.limit : 10,
+          pathPattern: isString(args?.pathPattern) ? args.pathPattern : undefined,
+          languages: isStringArray(args?.languages) ? args.languages : undefined,
+        });
         const formatted = results
           .map(
             (r, i) =>


### PR DESCRIPTION
## Summary
- Add optional `pathPattern` parameter for filtering search results by file path using glob patterns
- Add optional `languages` parameter for filtering results to specific programming languages
- Implement with backward-compatible method overloads so existing calls continue to work
- Add 7 new tests for the filtering functionality

## Test plan
- [x] Verify pathPattern glob matching works (e.g., `src/**`, `!test/**`)
- [x] Verify language filtering works (case-insensitive)
- [x] Verify multiple languages can be combined
- [x] Verify pathPattern and languages can be combined
- [x] Verify backward compatibility with existing search(query, limit) calls
- [x] All 315 tests pass

Closes lance-context-6ti

🤖 Generated with [Claude Code](https://claude.com/claude-code)