### PR TITLE
Track commit tool usage in dashboard

### DIFF
--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -13,7 +13,8 @@ export type CommandName =
   | 'search_similar'
   | 'get_index_status'
   | 'clear_index'
-  | 'get_project_instructions';
+  | 'get_project_instructions'
+  | 'commit';
 
 /**
  * Command usage statistics
@@ -49,6 +50,7 @@ const COMMAND_LABELS: Record<CommandName, string> = {
   get_index_status: 'Get Status',
   clear_index: 'Clear Index',
   get_project_instructions: 'Get Instructions',
+  commit: 'Commit',
 };
 
 export class DashboardStateManager extends EventEmitter {
@@ -226,6 +228,7 @@ export class DashboardStateManager extends EventEmitter {
       'get_index_status',
       'clear_index',
       'get_project_instructions',
+      'commit',
     ];
 
     return allCommands.map((command) => ({

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -910,10 +910,12 @@ export function getDashboardHTML(): string {
     // Charts.css color mapping
     const commandColors = {
       'search_code': '#58a6ff',
+      'search_similar': '#79c0ff',
       'index_codebase': '#3fb950',
       'get_index_status': '#a371f7',
       'clear_index': '#f85149',
-      'get_project_instructions': '#d29922'
+      'get_project_instructions': '#d29922',
+      'commit': '#56d364'
     };
 
     // Update usage chart using charts.css

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     'get_index_status',
     'clear_index',
     'get_project_instructions',
+    'commit',
   ];
   if (validCommands.includes(name as CommandName)) {
     dashboardState.recordCommandUsage(name as CommandName);


### PR DESCRIPTION
## Summary

- Adds `commit` tool to usage tracking so it appears in the dashboard chart
- Adds chart colors for `search_similar` (light blue) and `commit` (green)

## Changes

- `src/dashboard/state.ts`: Added `commit` to `CommandName` type, `COMMAND_LABELS`, and `allCommands` array
- `src/index.ts`: Added `commit` to `validCommands` array so usage is recorded
- `src/dashboard/ui.ts`: Added chart colors for `search_similar` and `commit`

## Test plan

- [x] TypeScript compiles successfully
- [x] All 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)