### PR TITLE
Add commit tool to priority instructions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,12 @@ const PRIORITY_INSTRUCTIONS = `
 
 3. **get_index_status** - Check if index is ready before searching
 
+4. **commit** - Use instead of \`git commit\`:
+   - Validates you're on a feature branch (not main)
+   - Checks message format (≤72 chars, imperative mood)
+   - Enforces single responsibility per commit
+   - Auto-appends Co-Authored-By trailer
+
 **Signs you should have used search_code:**
 - You used wildcards or regex alternation (e.g., \`foo|bar\`)
 - You made multiple search calls to find something


### PR DESCRIPTION
## Summary

Adds the `commit` tool to the priority instructions returned by `get_project_instructions`, reminding Claude to use the lance-context commit tool instead of `git commit` directly.

## Changes

Updated `PRIORITY_INSTRUCTIONS` in `src/index.ts` to include:
- `commit` tool as item #4 in the priority list
- Description of what validation the commit tool provides

## Test plan

- [x] TypeScript compiles successfully
- [x] All 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)