### PR TITLE
Preserve error context and stack traces

### DIFF
--- a/src/__tests__/utils/errors.test.ts
+++ b/src/__tests__/utils/errors.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  LanceContextError,
+  isDebugMode,
+  logError,
+  formatErrorResponse,
+  wrapError,
+} from '../../utils/errors.js';
+
+describe('errors', () => {
+  describe('LanceContextError', () => {
+    it('should create error with message and category', () => {
+      const error = new LanceContextError('Test error', 'validation');
+
+      expect(error.message).toBe('Test error');
+      expect(error.category).toBe('validation');
+      expect(error.name).toBe('LanceContextError');
+    });
+
+    it('should include context when provided', () => {
+      const error = new LanceContextError('Test error', 'search', { query: 'test' });
+
+      expect(error.context).toEqual({ query: 'test' });
+    });
+
+    it('should preserve cause error and stack', () => {
+      const cause = new Error('Original error');
+      const error = new LanceContextError('Wrapped error', 'internal', undefined, cause);
+
+      expect(error.cause).toBe(cause);
+      expect(error.stack).toContain('Caused by:');
+    });
+  });
+
+  describe('isDebugMode', () => {
+    const originalEnv = process.env.LANCE_CONTEXT_DEBUG;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.LANCE_CONTEXT_DEBUG;
+      } else {
+        process.env.LANCE_CONTEXT_DEBUG = originalEnv;
+      }
+    });
+
+    it('should return false when env var is not set', () => {
+      delete process.env.LANCE_CONTEXT_DEBUG;
+      expect(isDebugMode()).toBe(false);
+    });
+
+    it('should return true when env var is "1"', () => {
+      process.env.LANCE_CONTEXT_DEBUG = '1';
+      expect(isDebugMode()).toBe(true);
+    });
+
+    it('should return true when env var is "true"', () => {
+      process.env.LANCE_CONTEXT_DEBUG = 'true';
+      expect(isDebugMode()).toBe(true);
+    });
+
+    it('should return false for other values', () => {
+      process.env.LANCE_CONTEXT_DEBUG = 'false';
+      expect(isDebugMode()).toBe(false);
+    });
+  });
+
+  describe('logError', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('should log LanceContextError with category and stack', () => {
+      const error = new LanceContextError('Test error', 'validation', { key: 'value' });
+      logError(error, 'test_tool');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[lance-context] [test_tool] validation error: Test error'
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[lance-context] [test_tool] Context:',
+        expect.any(String)
+      );
+    });
+
+    it('should log regular Error with message and stack', () => {
+      const error = new Error('Regular error');
+      logError(error);
+
+      expect(consoleSpy).toHaveBeenCalledWith('[lance-context] Error: Regular error');
+    });
+
+    it('should log unknown errors', () => {
+      logError('string error');
+
+      expect(consoleSpy).toHaveBeenCalledWith('[lance-context] Unknown error:', 'string error');
+    });
+  });
+
+  describe('formatErrorResponse', () => {
+    const originalEnv = process.env.LANCE_CONTEXT_DEBUG;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.LANCE_CONTEXT_DEBUG;
+      } else {
+        process.env.LANCE_CONTEXT_DEBUG = originalEnv;
+      }
+    });
+
+    it('should format LanceContextError with category', () => {
+      delete process.env.LANCE_CONTEXT_DEBUG;
+      const error = new LanceContextError('Test error', 'validation');
+
+      const response = formatErrorResponse(error);
+
+      expect(response).toBe('Error [validation]: Test error');
+    });
+
+    it('should include stack trace in debug mode', () => {
+      process.env.LANCE_CONTEXT_DEBUG = '1';
+      const error = new LanceContextError('Test error', 'validation');
+
+      const response = formatErrorResponse(error);
+
+      expect(response).toContain('Error [validation]: Test error');
+      expect(response).toContain('Stack trace:');
+    });
+
+    it('should include context in debug mode', () => {
+      process.env.LANCE_CONTEXT_DEBUG = '1';
+      const error = new LanceContextError('Test error', 'validation', { tool: 'search' });
+
+      const response = formatErrorResponse(error);
+
+      expect(response).toContain('Context:');
+      expect(response).toContain('"tool": "search"');
+    });
+
+    it('should format regular Error', () => {
+      delete process.env.LANCE_CONTEXT_DEBUG;
+      const error = new Error('Regular error');
+
+      const response = formatErrorResponse(error);
+
+      expect(response).toBe('Error: Regular error');
+    });
+
+    it('should format unknown errors', () => {
+      const response = formatErrorResponse('string error');
+
+      expect(response).toBe('Error: string error');
+    });
+  });
+
+  describe('wrapError', () => {
+    it('should wrap Error with message and category', () => {
+      const cause = new Error('Original error');
+      const wrapped = wrapError('Wrapped message', 'internal', cause);
+
+      expect(wrapped).toBeInstanceOf(LanceContextError);
+      expect(wrapped.message).toBe('Wrapped message');
+      expect(wrapped.category).toBe('internal');
+      expect(wrapped.cause).toBe(cause);
+    });
+
+    it('should wrap non-Error with message and category', () => {
+      const wrapped = wrapError('Wrapped message', 'internal', 'string cause');
+
+      expect(wrapped).toBeInstanceOf(LanceContextError);
+      expect(wrapped.message).toBe('Wrapped message');
+      expect(wrapped.cause).toBeInstanceOf(Error);
+    });
+
+    it('should include context when provided', () => {
+      const cause = new Error('Original error');
+      const wrapped = wrapError('Wrapped message', 'git', cause, { command: 'git add' });
+
+      expect(wrapped.context).toEqual({ command: 'git add' });
+    });
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,120 @@
+/**
+ * Error handling utilities for lance-context MCP server.
+ *
+ * Provides structured error types, server-side logging, and debug mode support.
+ */
+
+/**
+ * Error categories for different failure modes
+ */
+export type ErrorCategory =
+  | 'validation' // Invalid input or arguments
+  | 'indexing' // Errors during indexing operations
+  | 'search' // Errors during search operations
+  | 'embedding' // Embedding generation failures
+  | 'config' // Configuration errors
+  | 'git' // Git operation failures
+  | 'internal'; // Unexpected internal errors
+
+/**
+ * Structured error with category and context
+ */
+export class LanceContextError extends Error {
+  readonly category: ErrorCategory;
+  readonly context?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    category: ErrorCategory,
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(message);
+    this.name = 'LanceContextError';
+    this.category = category;
+    this.context = context;
+    if (cause) {
+      this.cause = cause;
+      // Preserve original stack if available
+      if (cause.stack) {
+        this.stack = `${this.stack}\nCaused by: ${cause.stack}`;
+      }
+    }
+  }
+}
+
+/**
+ * Check if debug mode is enabled via environment variable
+ */
+export function isDebugMode(): boolean {
+  return process.env.LANCE_CONTEXT_DEBUG === '1' || process.env.LANCE_CONTEXT_DEBUG === 'true';
+}
+
+/**
+ * Log an error server-side with full context.
+ * Always logs to stderr for debugging purposes.
+ */
+export function logError(error: unknown, toolName?: string): void {
+  const prefix = toolName ? `[lance-context] [${toolName}]` : '[lance-context]';
+
+  if (error instanceof LanceContextError) {
+    console.error(`${prefix} ${error.category} error: ${error.message}`);
+    if (error.context) {
+      console.error(`${prefix} Context:`, JSON.stringify(error.context, null, 2));
+    }
+    if (error.stack) {
+      console.error(`${prefix} Stack trace:\n${error.stack}`);
+    }
+  } else if (error instanceof Error) {
+    console.error(`${prefix} Error: ${error.message}`);
+    if (error.stack) {
+      console.error(`${prefix} Stack trace:\n${error.stack}`);
+    }
+  } else {
+    console.error(`${prefix} Unknown error:`, error);
+  }
+}
+
+/**
+ * Format an error for client response.
+ * In debug mode, includes stack traces. Otherwise, just the message.
+ */
+export function formatErrorResponse(error: unknown): string {
+  const debug = isDebugMode();
+
+  if (error instanceof LanceContextError) {
+    let response = `Error [${error.category}]: ${error.message}`;
+    if (debug) {
+      if (error.context) {
+        response += `\n\nContext: ${JSON.stringify(error.context, null, 2)}`;
+      }
+      if (error.stack) {
+        response += `\n\nStack trace:\n${error.stack}`;
+      }
+    }
+    return response;
+  }
+
+  if (error instanceof Error) {
+    let response = `Error: ${error.message}`;
+    if (debug && error.stack) {
+      response += `\n\nStack trace:\n${error.stack}`;
+    }
+    return response;
+  }
+
+  return `Error: ${String(error)}`;
+}
+
+/**
+ * Wrap an error with additional context, preserving the original error.
+ */
+export function wrapError(
+  message: string,
+  category: ErrorCategory,
+  cause: unknown,
+  context?: Record<string, unknown>
+): LanceContextError {
+  const causeError = cause instanceof Error ? cause : new Error(String(cause));
+  return new LanceContextError(message, category, context, causeError);
+}


### PR DESCRIPTION
## Summary

Adds structured error handling that preserves error context and stack traces for better debugging:

- **Server-side logging**: All errors are logged to stderr with full stack traces
- **Debug mode**: Set `LANCE_CONTEXT_DEBUG=1` to include stack traces in client responses
- **Structured errors**: New `LanceContextError` class with error categories (validation, git, search, etc.)

## Changes

- **New file**: `src/utils/errors.ts` - Error handling utilities
  - `LanceContextError` class with category, context, and cause chain
  - `isDebugMode()` - Check if debug mode is enabled
  - `logError()` - Log errors server-side with full context
  - `formatErrorResponse()` - Format errors for client (respects debug mode)
  - `wrapError()` - Wrap errors with additional context

- **Updated**: `src/index.ts`
  - Uses structured errors for validation and git operations
  - Logs all errors server-side before returning response
  - Formats error response based on debug mode

- **New test file**: `src/__tests__/utils/errors.test.ts` - 18 tests

## Test plan

- [x] TypeScript compiles successfully
- [x] All 432 tests pass
- [x] No lint errors

Closes lance-context-5ct

🤖 Generated with [Claude Code](https://claude.com/claude-code)