### PR TITLE
feat(indexer): parallelize file processing during indexing

### DIFF
--- a/src/__tests__/utils/concurrency.test.ts
+++ b/src/__tests__/utils/concurrency.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { mapWithConcurrency, mapInBatches } from '../../utils/concurrency.js';
+
+describe('mapWithConcurrency', () => {
+  it('should process all items and return results in order', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await mapWithConcurrency(items, async (item) => item * 2, 2);
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('should limit concurrent operations', async () => {
+    let runningCount = 0;
+    let maxRunning = 0;
+
+    const items = [1, 2, 3, 4, 5, 6, 7, 8];
+    await mapWithConcurrency(
+      items,
+      async (item) => {
+        runningCount++;
+        maxRunning = Math.max(maxRunning, runningCount);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        runningCount--;
+        return item;
+      },
+      3 // concurrency limit
+    );
+
+    expect(maxRunning).toBeLessThanOrEqual(3);
+  });
+
+  it('should handle empty array', async () => {
+    const results = await mapWithConcurrency([], async (x) => x, 5);
+    expect(results).toEqual([]);
+  });
+
+  it('should handle single item', async () => {
+    const results = await mapWithConcurrency([42], async (x) => x * 2, 5);
+    expect(results).toEqual([84]);
+  });
+
+  it('should pass index to callback', async () => {
+    const items = ['a', 'b', 'c'];
+    const results = await mapWithConcurrency(items, async (item, index) => `${item}${index}`, 2);
+    expect(results).toEqual(['a0', 'b1', 'c2']);
+  });
+});
+
+describe('mapInBatches', () => {
+  it('should process all items in batches', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await mapInBatches(items, async (item) => item * 2, 2);
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('should call onBatchComplete after each batch', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const completedCounts: number[] = [];
+
+    await mapInBatches(
+      items,
+      async (item) => item,
+      2,
+      (completed, total) => {
+        completedCounts.push(completed);
+        expect(total).toBe(5);
+      }
+    );
+
+    expect(completedCounts).toEqual([2, 4, 5]);
+  });
+
+  it('should handle batch size larger than items', async () => {
+    const items = [1, 2, 3];
+    const results = await mapInBatches(items, async (item) => item * 2, 10);
+    expect(results).toEqual([2, 4, 6]);
+  });
+
+  it('should handle empty array', async () => {
+    const results = await mapInBatches([], async (x) => x, 5);
+    expect(results).toEqual([]);
+  });
+
+  it('should pass correct index to callback', async () => {
+    const items = ['a', 'b', 'c', 'd'];
+    const results = await mapInBatches(items, async (item, index) => `${item}${index}`, 2);
+    expect(results).toEqual(['a0', 'b1', 'c2', 'd3']);
+  });
+
+  it('should process batches sequentially', async () => {
+    const processOrder: number[] = [];
+    const items = [1, 2, 3, 4];
+
+    await mapInBatches(
+      items,
+      async (item) => {
+        processOrder.push(item);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return item;
+      },
+      2
+    );
+
+    // First batch (1, 2) completes before second batch (3, 4) starts
+    // Within each batch, order may vary due to Promise.all
+    // But we should see items 1,2 before 3,4
+    const firstBatchItems = processOrder.slice(0, 2).sort();
+    const secondBatchItems = processOrder.slice(2, 4).sort();
+    expect(firstBatchItems).toEqual([1, 2]);
+    expect(secondBatchItems).toEqual([3, 4]);
+  });
+});

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,73 @@
+/**
+ * Process items in parallel with controlled concurrency.
+ * Unlike Promise.all which starts all promises at once, this limits
+ * how many are running at any time.
+ *
+ * @param items - Items to process
+ * @param fn - Async function to apply to each item
+ * @param concurrency - Maximum number of concurrent operations (default: 10)
+ * @returns Promise resolving to results in the same order as items
+ *
+ * @example
+ * ```typescript
+ * const results = await mapWithConcurrency(
+ *   files,
+ *   async (file) => processFile(file),
+ *   10 // max 10 concurrent file operations
+ * );
+ * ```
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number = 10
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let currentIndex = 0;
+
+  async function processNext(): Promise<void> {
+    while (currentIndex < items.length) {
+      const index = currentIndex++;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  // Start 'concurrency' number of workers
+  const workers = Array(Math.min(concurrency, items.length))
+    .fill(null)
+    .map(() => processNext());
+
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Process items in batches, where each batch is processed in parallel.
+ * Useful when you want to process groups at a time with progress reporting.
+ *
+ * @param items - Items to process
+ * @param fn - Async function to apply to each item
+ * @param batchSize - Number of items per batch
+ * @param onBatchComplete - Optional callback after each batch completes
+ * @returns Promise resolving to results in the same order as items
+ */
+export async function mapInBatches<T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  batchSize: number = 10,
+  onBatchComplete?: (completedCount: number, totalCount: number) => void
+): Promise<R[]> {
+  const results: R[] = [];
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchStartIndex = i;
+    const batchResults = await Promise.all(
+      batch.map((item, idx) => fn(item, batchStartIndex + idx))
+    );
+    results.push(...batchResults);
+    onBatchComplete?.(results.length, items.length);
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Add `mapWithConcurrency` and `mapInBatches` utilities for controlled parallelism
- Update `indexFull` and `indexIncremental` to process files in parallel batches of 10
- Add comprehensive tests for concurrency utilities

## Motivation
Large codebases have many files to index. Sequential processing is slow because:
- File I/O is blocking
- AST parsing is CPU-intensive but can overlap with I/O
- Modern systems can handle concurrent operations efficiently

## Performance Impact
I/O-bound operations now run concurrently instead of sequentially, significantly improving throughput on large codebases.

## Test plan
- [x] All existing indexer tests pass
- [x] New concurrency utility tests pass (11 tests)
- [x] Verified correct ordering of results

🤖 Generated with [Claude Code](https://claude.com/claude-code)