### PR TITLE
refactor(dashboard): extract DashboardManager class for testability

### DIFF
--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -9,8 +9,6 @@ import { dashboardState } from './state.js';
 import type { CodeIndexer } from '../search/indexer.js';
 import type { LanceContextConfig } from '../config.js';
 
-let serverInstance: DashboardServer | null = null;
-
 export interface DashboardOptions {
   /** Port to use (default: auto-discover from 24300) */
   port?: number;
@@ -23,49 +21,98 @@ export interface DashboardOptions {
 }
 
 /**
+ * DashboardManager - Encapsulates dashboard server state for testability.
+ *
+ * This class allows creating isolated instances for testing while maintaining
+ * backward compatibility through the default instance and module-level functions.
+ */
+export class DashboardManager {
+  private serverInstance: DashboardServer | null = null;
+
+  /**
+   * Start the dashboard server.
+   * Returns the server instance with URL and stop function.
+   */
+  async start(options: DashboardOptions = {}): Promise<DashboardServer> {
+    if (this.serverInstance) {
+      return this.serverInstance;
+    }
+
+    // Set up dashboard state if provided
+    if (options.indexer) {
+      dashboardState.setIndexer(options.indexer);
+    }
+    if (options.config) {
+      dashboardState.setConfig(options.config);
+    }
+    if (options.projectPath) {
+      dashboardState.setProjectPath(options.projectPath);
+    }
+
+    this.serverInstance = await startServer(options.port);
+    return this.serverInstance;
+  }
+
+  /**
+   * Stop the dashboard server.
+   */
+  async stop(): Promise<void> {
+    if (this.serverInstance) {
+      await this.serverInstance.stop();
+      this.serverInstance = null;
+    }
+  }
+
+  /**
+   * Check if the dashboard is running.
+   */
+  isRunning(): boolean {
+    return this.serverInstance !== null;
+  }
+
+  /**
+   * Get the dashboard URL if running.
+   */
+  getUrl(): string | null {
+    return this.serverInstance?.url ?? null;
+  }
+
+  /**
+   * Get the current server instance (for testing).
+   */
+  getServerInstance(): DashboardServer | null {
+    return this.serverInstance;
+  }
+}
+
+// Default instance for backward compatibility
+export const defaultDashboardManager = new DashboardManager();
+
+/**
  * Start the dashboard server.
  * Returns the server instance with URL and stop function.
  */
 export async function startDashboard(options: DashboardOptions = {}): Promise<DashboardServer> {
-  if (serverInstance) {
-    return serverInstance;
-  }
-
-  // Set up dashboard state if provided
-  if (options.indexer) {
-    dashboardState.setIndexer(options.indexer);
-  }
-  if (options.config) {
-    dashboardState.setConfig(options.config);
-  }
-  if (options.projectPath) {
-    dashboardState.setProjectPath(options.projectPath);
-  }
-
-  serverInstance = await startServer(options.port);
-  return serverInstance;
+  return defaultDashboardManager.start(options);
 }
 
 /**
  * Stop the dashboard server.
  */
 export async function stopDashboard(): Promise<void> {
-  if (serverInstance) {
-    await serverInstance.stop();
-    serverInstance = null;
-  }
+  return defaultDashboardManager.stop();
 }
 
 /**
  * Check if the dashboard is running.
  */
 export function isDashboardRunning(): boolean {
-  return serverInstance !== null;
+  return defaultDashboardManager.isRunning();
 }
 
 /**
  * Get the dashboard URL if running.
  */
 export function getDashboardUrl(): string | null {
-  return serverInstance?.url ?? null;
+  return defaultDashboardManager.getUrl();
 }


### PR DESCRIPTION
## Summary
- Extract DashboardManager class from module-level singleton
- Export `defaultDashboardManager` for direct test access
- Maintain backward-compatible module-level functions (startDashboard, stopDashboard, etc.)
- Remove duplicate DashboardOptions interface

## Motivation
The previous singleton pattern made unit testing difficult because:
- State persisted between tests
- No way to inject mock dependencies
- Hard to reset state cleanly

## Test plan
- [x] All existing dashboard tests pass
- [x] Module-level functions maintain same behavior
- [x] DashboardManager can be instantiated independently for testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)