### PR TITLE
feat: add Serena-like symbolic code analysis tools

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,0 +1,201 @@
+/**
+ * File-based memory system for storing project-specific information.
+ * Stores human-readable markdown files in .lance-context/memories/
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Memory entry metadata
+ */
+export interface MemoryInfo {
+  name: string;
+  size: number;
+  lastModified: Date;
+}
+
+/**
+ * Memory manager for storing and retrieving project memories.
+ */
+export class MemoryManager {
+  private projectPath: string;
+  private memoriesPath: string;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+    this.memoriesPath = path.join(projectPath, '.lance-context', 'memories');
+  }
+
+  /**
+   * Ensure the memories directory exists.
+   */
+  private async ensureDirectory(): Promise<void> {
+    await fs.mkdir(this.memoriesPath, { recursive: true });
+  }
+
+  /**
+   * Normalize a memory file name (ensure .md extension).
+   */
+  private normalizeFileName(name: string): string {
+    if (!name.endsWith('.md')) {
+      return `${name}.md`;
+    }
+    return name;
+  }
+
+  /**
+   * Get the full path to a memory file.
+   */
+  private getMemoryPath(name: string): string {
+    return path.join(this.memoriesPath, this.normalizeFileName(name));
+  }
+
+  /**
+   * Write content to a memory file.
+   */
+  async writeMemory(name: string, content: string): Promise<void> {
+    await this.ensureDirectory();
+    const memoryPath = this.getMemoryPath(name);
+    await fs.writeFile(memoryPath, content, 'utf-8');
+  }
+
+  /**
+   * Read content from a memory file.
+   */
+  async readMemory(name: string): Promise<string> {
+    const memoryPath = this.getMemoryPath(name);
+    try {
+      return await fs.readFile(memoryPath, 'utf-8');
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`Memory not found: ${name}`);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * List all memory files.
+   */
+  async listMemories(): Promise<MemoryInfo[]> {
+    try {
+      await this.ensureDirectory();
+      const files = await fs.readdir(this.memoriesPath);
+      const memories: MemoryInfo[] = [];
+
+      for (const file of files) {
+        if (file.endsWith('.md')) {
+          const filePath = path.join(this.memoriesPath, file);
+          const stat = await fs.stat(filePath);
+          memories.push({
+            name: file.replace(/\.md$/, ''),
+            size: stat.size,
+            lastModified: stat.mtime,
+          });
+        }
+      }
+
+      // Sort by last modified (most recent first)
+      memories.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+
+      return memories;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Delete a memory file.
+   */
+  async deleteMemory(name: string): Promise<void> {
+    const memoryPath = this.getMemoryPath(name);
+    try {
+      await fs.unlink(memoryPath);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`Memory not found: ${name}`);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Edit a memory file using find/replace.
+   */
+  async editMemory(
+    name: string,
+    needle: string,
+    replacement: string,
+    mode: 'literal' | 'regex'
+  ): Promise<{ matchCount: number }> {
+    const content = await this.readMemory(name);
+
+    let newContent: string;
+    let matchCount: number;
+
+    if (mode === 'literal') {
+      // Count matches
+      matchCount = content.split(needle).length - 1;
+      if (matchCount === 0) {
+        throw new Error(`Pattern not found in memory: ${needle}`);
+      }
+      // Replace all occurrences
+      newContent = content.split(needle).join(replacement);
+    } else {
+      // Regex mode
+      let regex: RegExp;
+      try {
+        regex = new RegExp(needle, 'gms'); // DOTALL and MULTILINE enabled
+      } catch (e) {
+        throw new Error(`Invalid regex pattern: ${needle}. ${e instanceof Error ? e.message : ''}`);
+      }
+
+      const matches = content.match(regex);
+      matchCount = matches ? matches.length : 0;
+
+      if (matchCount === 0) {
+        throw new Error(`Pattern not found in memory: ${needle}`);
+      }
+
+      newContent = content.replace(regex, replacement);
+    }
+
+    await this.writeMemory(name, newContent);
+
+    return { matchCount };
+  }
+
+  /**
+   * Check if a memory exists.
+   */
+  async memoryExists(name: string): Promise<boolean> {
+    const memoryPath = this.getMemoryPath(name);
+    try {
+      await fs.access(memoryPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Format memory list for display.
+ */
+export function formatMemoryList(memories: MemoryInfo[]): string {
+  if (memories.length === 0) {
+    return 'No memories found.';
+  }
+
+  const parts: string[] = [];
+  parts.push(`Found ${memories.length} memor${memories.length === 1 ? 'y' : 'ies'}:\n`);
+
+  for (const memory of memories) {
+    const date = memory.lastModified.toISOString().split('T')[0];
+    const sizeKb = (memory.size / 1024).toFixed(1);
+    parts.push(`- **${memory.name}** (${sizeKb} KB, modified ${date})`);
+  }
+
+  return parts.join('\n');
+}

--- a/src/symbols/index.ts
+++ b/src/symbols/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Symbolic code analysis module.
+ * Provides Serena-like symbol navigation and analysis tools.
+ */
+
+// Types
+export * from './types.js';
+
+// Name path utilities
+export * from './name-path.js';
+
+// Symbol extraction
+export { SymbolExtractor } from './symbol-extractor.js';
+
+// Pattern search
+export { searchForPattern, formatPatternSearchResults } from './pattern-search.js';
+
+// Reference finding
+export { ReferenceFinder, formatReferencesResult } from './reference-finder.js';
+
+// Symbol editing
+export { SymbolEditor } from './symbol-editor.js';
+export type { EditResult, ReplaceSymbolOptions, InsertSymbolOptions } from './symbol-editor.js';
+
+// Symbol renaming
+export { SymbolRenamer, formatRenameResult } from './symbol-renamer.js';
+export type { RenameResult, RenameSymbolOptions, RenameFileResult } from './symbol-renamer.js';

--- a/src/symbols/name-path.ts
+++ b/src/symbols/name-path.ts
@@ -1,0 +1,239 @@
+/**
+ * Name path utilities for parsing and matching hierarchical symbol paths.
+ *
+ * Name path format:
+ * - "/ClassName/methodName" - Absolute path (must match from root)
+ * - "ClassName/methodName" - Relative path (matches any suffix)
+ * - "methodName" - Simple name (matches any symbol with that name)
+ * - "Class/get*" - With glob pattern (substring matching on last element)
+ *
+ * Uses "/" as separator to match Serena's convention.
+ */
+
+/**
+ * Parsed name path pattern for matching.
+ */
+export interface ParsedNamePath {
+  /** Whether the path is absolute (starts with /) */
+  isAbsolute: boolean;
+  /** Path segments */
+  segments: string[];
+  /** Whether to use substring matching on last segment */
+  substringMatch: boolean;
+  /** Optional overload index (e.g., [0], [1]) */
+  overloadIndex?: number;
+}
+
+/**
+ * Parse a name path pattern into its components.
+ *
+ * @param pattern - The name path pattern to parse
+ * @returns Parsed pattern components
+ *
+ * @example
+ * parseNamePath("/MyClass/myMethod") // absolute path
+ * parseNamePath("MyClass/myMethod")  // relative path
+ * parseNamePath("myMethod")          // simple name
+ * parseNamePath("MyClass/get*")      // with glob
+ * parseNamePath("MyClass/method[0]") // with overload index
+ */
+export function parseNamePath(pattern: string): ParsedNamePath {
+  let isAbsolute = false;
+  let workingPattern = pattern.trim();
+
+  // Check for absolute path
+  if (workingPattern.startsWith('/')) {
+    isAbsolute = true;
+    workingPattern = workingPattern.slice(1);
+  }
+
+  // Check for overload index at the end (e.g., "[0]", "[1]")
+  let overloadIndex: number | undefined;
+  const overloadMatch = workingPattern.match(/\[(\d+)\]$/);
+  if (overloadMatch) {
+    overloadIndex = parseInt(overloadMatch[1], 10);
+    workingPattern = workingPattern.slice(0, -overloadMatch[0].length);
+  }
+
+  // Split into segments
+  const segments = workingPattern.split('/').filter((s) => s.length > 0);
+
+  // Check if last segment has glob pattern (ends with *)
+  const substringMatch = segments.length > 0 && segments[segments.length - 1].endsWith('*');
+
+  // Remove the * from last segment if present
+  if (substringMatch && segments.length > 0) {
+    segments[segments.length - 1] = segments[segments.length - 1].slice(0, -1);
+  }
+
+  return {
+    isAbsolute,
+    segments,
+    substringMatch,
+    overloadIndex,
+  };
+}
+
+/**
+ * Build a name path from parent path and name.
+ *
+ * @param parentPath - Parent symbol's name path (or undefined for top-level)
+ * @param name - Symbol's name
+ * @returns Complete name path
+ *
+ * @example
+ * buildNamePath(undefined, "MyClass")     // "/MyClass"
+ * buildNamePath("/MyClass", "myMethod")   // "/MyClass/myMethod"
+ */
+export function buildNamePath(parentPath: string | undefined, name: string): string {
+  if (!parentPath) {
+    return `/${name}`;
+  }
+  return `${parentPath}/${name}`;
+}
+
+/**
+ * Check if a name path matches a pattern.
+ *
+ * @param namePath - The full name path of a symbol (e.g., "/MyClass/myMethod")
+ * @param pattern - The parsed pattern to match against
+ * @param useSubstringMatching - Override substring matching for last segment
+ * @returns True if the name path matches the pattern
+ *
+ * @example
+ * // Absolute match
+ * matchNamePath("/MyClass/myMethod", parseNamePath("/MyClass/myMethod")) // true
+ * matchNamePath("/MyClass/myMethod", parseNamePath("/OtherClass/myMethod")) // false
+ *
+ * // Relative match (suffix)
+ * matchNamePath("/MyClass/myMethod", parseNamePath("myMethod")) // true
+ * matchNamePath("/MyClass/myMethod", parseNamePath("MyClass/myMethod")) // true
+ *
+ * // Substring match
+ * matchNamePath("/MyClass/getValue", parseNamePath("get*")) // true
+ */
+export function matchNamePath(
+  namePath: string,
+  pattern: ParsedNamePath,
+  useSubstringMatching?: boolean
+): boolean {
+  // Normalize the name path (ensure it starts with /)
+  const normalizedPath = namePath.startsWith('/') ? namePath : `/${namePath}`;
+  const pathSegments = normalizedPath.split('/').filter((s) => s.length > 0);
+
+  const { isAbsolute, segments: patternSegments, substringMatch } = pattern;
+  const shouldSubstring = useSubstringMatching ?? substringMatch;
+
+  if (patternSegments.length === 0) {
+    return true; // Empty pattern matches everything
+  }
+
+  if (isAbsolute) {
+    // Absolute path must match from the start
+    if (pathSegments.length !== patternSegments.length) {
+      return false;
+    }
+
+    for (let i = 0; i < patternSegments.length; i++) {
+      const isLastSegment = i === patternSegments.length - 1;
+      if (!segmentMatches(pathSegments[i], patternSegments[i], isLastSegment && shouldSubstring)) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Relative path - find suffix match
+    if (pathSegments.length < patternSegments.length) {
+      return false;
+    }
+
+    // Try to match from the end
+    const startIdx = pathSegments.length - patternSegments.length;
+    for (let i = 0; i < patternSegments.length; i++) {
+      const isLastSegment = i === patternSegments.length - 1;
+      if (
+        !segmentMatches(
+          pathSegments[startIdx + i],
+          patternSegments[i],
+          isLastSegment && shouldSubstring
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/**
+ * Check if a path segment matches a pattern segment.
+ */
+function segmentMatches(
+  pathSegment: string,
+  patternSegment: string,
+  useSubstring: boolean
+): boolean {
+  if (useSubstring) {
+    return pathSegment.toLowerCase().startsWith(patternSegment.toLowerCase());
+  }
+  return pathSegment === patternSegment;
+}
+
+/**
+ * Extract the last segment (symbol name) from a name path.
+ *
+ * @param namePath - Full name path
+ * @returns The last segment (symbol name)
+ *
+ * @example
+ * getSymbolName("/MyClass/myMethod") // "myMethod"
+ * getSymbolName("/topLevelFunc")     // "topLevelFunc"
+ */
+export function getSymbolName(namePath: string): string {
+  const segments = namePath.split('/').filter((s) => s.length > 0);
+  return segments[segments.length - 1] || '';
+}
+
+/**
+ * Get the parent path from a name path.
+ *
+ * @param namePath - Full name path
+ * @returns Parent path, or undefined if top-level
+ *
+ * @example
+ * getParentPath("/MyClass/myMethod") // "/MyClass"
+ * getParentPath("/topLevelFunc")     // undefined
+ */
+export function getParentPath(namePath: string): string | undefined {
+  const segments = namePath.split('/').filter((s) => s.length > 0);
+  if (segments.length <= 1) {
+    return undefined;
+  }
+  return '/' + segments.slice(0, -1).join('/');
+}
+
+/**
+ * Get the depth of a name path (number of segments - 1).
+ *
+ * @param namePath - Full name path
+ * @returns Depth (0 for top-level)
+ *
+ * @example
+ * getNamePathDepth("/topLevel")           // 0
+ * getNamePathDepth("/MyClass/myMethod")   // 1
+ */
+export function getNamePathDepth(namePath: string): number {
+  const segments = namePath.split('/').filter((s) => s.length > 0);
+  return Math.max(0, segments.length - 1);
+}
+
+/**
+ * Create a display-friendly version of a name path.
+ * Removes the leading slash for cleaner display.
+ *
+ * @param namePath - Full name path
+ * @returns Display string
+ */
+export function formatNamePath(namePath: string): string {
+  return namePath.startsWith('/') ? namePath.slice(1) : namePath;
+}

--- a/src/symbols/pattern-search.ts
+++ b/src/symbols/pattern-search.ts
@@ -1,0 +1,272 @@
+/**
+ * Pattern search for finding text patterns in the codebase.
+ * Supports regex patterns with context lines.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { glob } from 'glob';
+import { minimatch } from 'minimatch';
+import { PatternSearchResult, PatternMatch, SearchPatternOptions } from './types.js';
+
+/**
+ * Default extensions for code files
+ */
+const CODE_FILE_EXTENSIONS = [
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mts',
+  '.cts',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.pyi',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.rb',
+  '.php',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.swift',
+  '.scala',
+  '.lua',
+  '.r',
+  '.R',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.sql',
+];
+
+/**
+ * Default directories to exclude
+ */
+const DEFAULT_EXCLUDE_PATTERNS = [
+  'node_modules/**',
+  '.git/**',
+  'dist/**',
+  'build/**',
+  'coverage/**',
+  '__pycache__/**',
+  '.next/**',
+  '.cache/**',
+  'vendor/**',
+];
+
+/**
+ * Maximum default response size in characters
+ */
+const DEFAULT_MAX_ANSWER_CHARS = 50000;
+
+/**
+ * Search for a pattern in the codebase.
+ */
+export async function searchForPattern(
+  projectPath: string,
+  options: SearchPatternOptions
+): Promise<PatternSearchResult> {
+  const {
+    substringPattern,
+    relativePath = '',
+    restrictSearchToCodeFiles = false,
+    pathsIncludeGlob,
+    pathsExcludeGlob,
+    contextLinesBefore = 0,
+    contextLinesAfter = 0,
+    maxAnswerChars = DEFAULT_MAX_ANSWER_CHARS,
+  } = options;
+
+  // Compile the pattern
+  let regex: RegExp;
+  try {
+    regex = new RegExp(substringPattern, 'gm');
+  } catch (e) {
+    throw new Error(
+      `Invalid regex pattern: ${substringPattern}. ${e instanceof Error ? e.message : ''}`
+    );
+  }
+
+  // Determine the search path
+  const searchPath = relativePath ? path.join(projectPath, relativePath) : projectPath;
+
+  // Check if searchPath is a file or directory
+  let files: string[];
+  try {
+    const stat = await fs.stat(searchPath);
+    if (stat.isFile()) {
+      files = [searchPath];
+    } else {
+      files = await findFiles(searchPath, {
+        codeFilesOnly: restrictSearchToCodeFiles,
+        includeGlob: pathsIncludeGlob,
+        excludeGlob: pathsExcludeGlob,
+      });
+    }
+  } catch {
+    throw new Error(`Path not found: ${relativePath || '.'}`);
+  }
+
+  const matches: Record<string, PatternMatch[]> = {};
+  let totalMatches = 0;
+  let totalChars = 0;
+
+  for (const file of files) {
+    if (totalChars >= maxAnswerChars) {
+      break;
+    }
+
+    try {
+      const content = await fs.readFile(file, 'utf-8');
+      const lines = content.split('\n');
+      const fileMatches: PatternMatch[] = [];
+
+      // Find all matches in the file
+      let match: RegExpExecArray | null;
+      regex.lastIndex = 0; // Reset regex state
+
+      while ((match = regex.exec(content)) !== null) {
+        // Find the line number of the match
+        const beforeMatch = content.slice(0, match.index);
+        const lineNumber = beforeMatch.split('\n').length;
+
+        // Get context lines
+        const startLine = Math.max(0, lineNumber - 1 - contextLinesBefore);
+        const endLine = Math.min(lines.length, lineNumber + contextLinesAfter);
+        const contextContent = lines.slice(startLine, endLine).join('\n');
+
+        // Calculate match position within line
+        const lineStart = beforeMatch.lastIndexOf('\n') + 1;
+        const matchStart = match.index - lineStart;
+
+        fileMatches.push({
+          line: lineNumber,
+          content: contextContent,
+          matchStart,
+          matchLength: match[0].length,
+        });
+
+        totalMatches++;
+        totalChars += contextContent.length + 50; // Approximate overhead
+
+        if (totalChars >= maxAnswerChars) {
+          break;
+        }
+
+        // Prevent infinite loops on zero-length matches
+        if (match[0].length === 0) {
+          regex.lastIndex++;
+        }
+      }
+
+      if (fileMatches.length > 0) {
+        const relPath = path.relative(projectPath, file);
+        matches[relPath] = fileMatches;
+      }
+    } catch {
+      // Skip files that can't be read (binary, etc.)
+      continue;
+    }
+  }
+
+  return {
+    matches,
+    totalMatches,
+  };
+}
+
+interface FindFilesOptions {
+  codeFilesOnly?: boolean;
+  includeGlob?: string;
+  excludeGlob?: string;
+}
+
+async function findFiles(searchPath: string, options: FindFilesOptions): Promise<string[]> {
+  const { codeFilesOnly, includeGlob, excludeGlob } = options;
+
+  // Build glob patterns
+  let patterns: string[];
+  if (codeFilesOnly) {
+    patterns = CODE_FILE_EXTENSIONS.map((ext) => `**/*${ext}`);
+  } else if (includeGlob) {
+    patterns = [includeGlob];
+  } else {
+    patterns = ['**/*'];
+  }
+
+  // Build exclude patterns
+  const excludePatterns = [...DEFAULT_EXCLUDE_PATTERNS];
+  if (excludeGlob) {
+    excludePatterns.push(excludeGlob);
+  }
+
+  const files: string[] = [];
+  for (const pattern of patterns) {
+    const matches = await glob(pattern, {
+      cwd: searchPath,
+      ignore: excludePatterns,
+      absolute: true,
+      nodir: true,
+    });
+    files.push(...matches);
+  }
+
+  // Apply additional filtering if both includeGlob and excludeGlob are specified
+  let filtered = files;
+  if (includeGlob && !codeFilesOnly) {
+    filtered = filtered.filter((f) => {
+      const rel = path.relative(searchPath, f);
+      return minimatch(rel, includeGlob);
+    });
+  }
+  if (excludeGlob) {
+    filtered = filtered.filter((f) => {
+      const rel = path.relative(searchPath, f);
+      return !minimatch(rel, excludeGlob);
+    });
+  }
+
+  // Remove duplicates
+  return [...new Set(filtered)];
+}
+
+/**
+ * Format pattern search results for display.
+ */
+export function formatPatternSearchResults(result: PatternSearchResult): string {
+  if (result.totalMatches === 0) {
+    return 'No matches found.';
+  }
+
+  const parts: string[] = [];
+  parts.push(`Found ${result.totalMatches} match${result.totalMatches === 1 ? '' : 'es'}:\n`);
+
+  for (const [filepath, fileMatches] of Object.entries(result.matches)) {
+    parts.push(`\n## ${filepath}\n`);
+
+    for (const match of fileMatches) {
+      // Format with line numbers
+      const lines = match.content.split('\n');
+      const startLine = match.line - Math.floor((lines.length - 1) / 2);
+
+      const formatted = lines
+        .map((line, idx) => {
+          const lineNum = startLine + idx;
+          const isMatchLine = lineNum === match.line;
+          const prefix = isMatchLine ? '>' : ' ';
+          return `${prefix} ${lineNum.toString().padStart(4)}: ${line}`;
+        })
+        .join('\n');
+
+      parts.push('```\n' + formatted + '\n```\n');
+    }
+  }
+
+  return parts.join('');
+}

--- a/src/symbols/reference-finder.ts
+++ b/src/symbols/reference-finder.ts
@@ -1,0 +1,524 @@
+/**
+ * Reference finder for locating all usages of a symbol.
+ * Uses Tree-sitter to find identifier references across the codebase.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { glob } from 'glob';
+import * as ts from 'typescript';
+import type { Parser as ParserType, Language, Node as SyntaxNode } from 'web-tree-sitter';
+import { SymbolReference, Symbol, SymbolKind, FindReferencesOptions } from './types.js';
+import { SymbolExtractor } from './symbol-extractor.js';
+import { getSymbolName, parseNamePath, matchNamePath } from './name-path.js';
+
+// Dynamic import for ESM compatibility
+interface ParserModule {
+  Parser: typeof ParserType;
+  Language: typeof Language;
+}
+
+let parserModule: ParserModule | null = null;
+const loadParserModule = async (): Promise<ParserModule> => {
+  if (!parserModule) {
+    const mod = await import('web-tree-sitter');
+    parserModule = {
+      Parser: mod.Parser,
+      Language: mod.Language,
+    };
+  }
+  return parserModule;
+};
+
+/**
+ * Language configuration for reference finding
+ */
+interface LanguageConfig {
+  wasmFile: string;
+  extensions: string[];
+  identifierTypes: string[];
+}
+
+const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
+  python: {
+    wasmFile: 'tree-sitter-python.wasm',
+    extensions: ['.py', '.pyi'],
+    identifierTypes: ['identifier'],
+  },
+  go: {
+    wasmFile: 'tree-sitter-go.wasm',
+    extensions: ['.go'],
+    identifierTypes: ['identifier', 'type_identifier', 'field_identifier'],
+  },
+  rust: {
+    wasmFile: 'tree-sitter-rust.wasm',
+    extensions: ['.rs'],
+    identifierTypes: ['identifier', 'type_identifier', 'field_identifier'],
+  },
+  java: {
+    wasmFile: 'tree-sitter-java.wasm',
+    extensions: ['.java'],
+    identifierTypes: ['identifier', 'type_identifier'],
+  },
+  ruby: {
+    wasmFile: 'tree-sitter-ruby.wasm',
+    extensions: ['.rb'],
+    identifierTypes: ['identifier', 'constant'],
+  },
+};
+
+/**
+ * Default patterns for files to exclude when searching
+ */
+const DEFAULT_EXCLUDE_PATTERNS = [
+  'node_modules/**',
+  '.git/**',
+  'dist/**',
+  'build/**',
+  'coverage/**',
+  '__pycache__/**',
+  '.next/**',
+  '.cache/**',
+];
+
+/**
+ * Find references to a symbol across the codebase.
+ */
+export class ReferenceFinder {
+  private static parser: ParserType | null = null;
+  private static loadedLanguages: Map<string, Language> = new Map();
+  private static initPromise: Promise<void> | null = null;
+  private static wasmBasePath: string | null = null;
+
+  private projectPath: string;
+  private symbolExtractor: SymbolExtractor;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+    this.symbolExtractor = new SymbolExtractor(projectPath);
+  }
+
+  /**
+   * Initialize the tree-sitter parser.
+   */
+  private static async initialize(): Promise<void> {
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = (async () => {
+      this.wasmBasePath = await this.findWasmBasePath();
+      const module = await loadParserModule();
+
+      const webTreeSitterWasm = path.join(
+        process.cwd(),
+        'node_modules',
+        'web-tree-sitter',
+        'web-tree-sitter.wasm'
+      );
+      await module.Parser.init({
+        locateFile: () => webTreeSitterWasm,
+      });
+      this.parser = new module.Parser();
+    })();
+
+    return this.initPromise;
+  }
+
+  private static async findWasmBasePath(): Promise<string> {
+    const { fileURLToPath } = await import('url');
+    const possiblePaths = [
+      path.join(process.cwd(), 'node_modules', '@vscode', 'tree-sitter-wasm', 'wasm'),
+      path.join(
+        fileURLToPath(import.meta.url),
+        '..',
+        '..',
+        '..',
+        'node_modules',
+        '@vscode',
+        'tree-sitter-wasm',
+        'wasm'
+      ),
+    ];
+
+    for (const p of possiblePaths) {
+      try {
+        await fs.access(p);
+        return p;
+      } catch {
+        // Try next
+      }
+    }
+
+    throw new Error('Could not find @vscode/tree-sitter-wasm package.');
+  }
+
+  private static getLanguageConfig(filepath: string): LanguageConfig | null {
+    const ext = path.extname(filepath).toLowerCase();
+    for (const [, config] of Object.entries(LANGUAGE_CONFIGS)) {
+      if (config.extensions.includes(ext)) {
+        return config;
+      }
+    }
+    return null;
+  }
+
+  private static async loadLanguage(config: LanguageConfig): Promise<Language> {
+    const cached = this.loadedLanguages.get(config.wasmFile);
+    if (cached) {
+      return cached;
+    }
+
+    if (!this.wasmBasePath) {
+      throw new Error('ReferenceFinder not initialized.');
+    }
+
+    const module = await loadParserModule();
+    const wasmPath = path.join(this.wasmBasePath, config.wasmFile);
+    const wasmBytes = await fs.readFile(wasmPath);
+    const language = await module.Language.load(wasmBytes);
+    this.loadedLanguages.set(config.wasmFile, language);
+    return language;
+  }
+
+  /**
+   * Find all references to a symbol.
+   */
+  async findReferences(options: FindReferencesOptions): Promise<SymbolReference[]> {
+    const { namePath, relativePath, includeInfo = false, includeKinds, excludeKinds } = options;
+
+    // First, find the target symbol
+    const fullPath = path.join(this.projectPath, relativePath);
+    const symbols = await this.symbolExtractor.extractSymbols(fullPath, false);
+
+    const pattern = parseNamePath(namePath);
+    const targetSymbol = this.findSymbolByPattern(symbols, pattern);
+
+    if (!targetSymbol) {
+      throw new Error(`Symbol not found: ${namePath} in ${relativePath}`);
+    }
+
+    const symbolName = getSymbolName(targetSymbol.namePath);
+
+    // Find all files to search
+    const files = await this.findFilesToSearch();
+
+    const references: SymbolReference[] = [];
+
+    for (const file of files) {
+      const fileRefs = await this.findReferencesInFile(
+        file,
+        symbolName,
+        targetSymbol,
+        includeInfo,
+        includeKinds,
+        excludeKinds
+      );
+      references.push(...fileRefs);
+    }
+
+    return references;
+  }
+
+  private findSymbolByPattern(
+    symbols: Symbol[],
+    pattern: ReturnType<typeof parseNamePath>
+  ): Symbol | null {
+    for (const symbol of symbols) {
+      if (matchNamePath(symbol.namePath, pattern)) {
+        return symbol;
+      }
+      if (symbol.children) {
+        const found = this.findSymbolByPattern(symbol.children, pattern);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  private async findFilesToSearch(): Promise<string[]> {
+    const codeExtensions = [
+      '.ts',
+      '.tsx',
+      '.js',
+      '.jsx',
+      '.mts',
+      '.cts',
+      '.mjs',
+      '.cjs',
+      '.py',
+      '.pyi',
+      '.go',
+      '.rs',
+      '.java',
+      '.kt',
+      '.rb',
+    ];
+
+    const patterns = codeExtensions.map((ext) => `**/*${ext}`);
+    const files: string[] = [];
+
+    for (const pattern of patterns) {
+      const matches = await glob(pattern, {
+        cwd: this.projectPath,
+        ignore: DEFAULT_EXCLUDE_PATTERNS,
+        absolute: true,
+      });
+      files.push(...matches);
+    }
+
+    return [...new Set(files)];
+  }
+
+  private async findReferencesInFile(
+    filepath: string,
+    symbolName: string,
+    targetSymbol: Symbol,
+    includeInfo: boolean,
+    includeKinds?: SymbolKind[],
+    excludeKinds?: SymbolKind[]
+  ): Promise<SymbolReference[]> {
+    const ext = path.extname(filepath).toLowerCase();
+    const relativePath = path.relative(this.projectPath, filepath);
+    const references: SymbolReference[] = [];
+
+    try {
+      const content = await fs.readFile(filepath, 'utf-8');
+      const lines = content.split('\n');
+
+      // Skip the definition file for non-exported symbols
+      if (path.relative(this.projectPath, filepath) === targetSymbol.location.filepath) {
+        // Still find references within the same file, but skip the definition itself
+      }
+
+      // Use TypeScript for TS/JS files
+      if (['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'].includes(ext)) {
+        const refs = this.findReferencesWithTypeScript(
+          content,
+          filepath,
+          relativePath,
+          lines,
+          symbolName,
+          targetSymbol
+        );
+        references.push(...refs);
+      } else {
+        // Use tree-sitter for other languages
+        const config = ReferenceFinder.getLanguageConfig(filepath);
+        if (config) {
+          const refs = await this.findReferencesWithTreeSitter(
+            content,
+            filepath,
+            relativePath,
+            lines,
+            symbolName,
+            targetSymbol,
+            config
+          );
+          references.push(...refs);
+        }
+      }
+
+      // Filter by kinds
+      return references.filter((ref) => {
+        if (excludeKinds && excludeKinds.includes(ref.referencingSymbol.kind)) {
+          return false;
+        }
+        if (includeKinds && !includeKinds.includes(ref.referencingSymbol.kind)) {
+          return false;
+        }
+        return true;
+      });
+    } catch {
+      // Skip files that can't be read
+      return [];
+    }
+  }
+
+  private findReferencesWithTypeScript(
+    content: string,
+    _filepath: string,
+    relativePath: string,
+    lines: string[],
+    symbolName: string,
+    targetSymbol: Symbol
+  ): SymbolReference[] {
+    const references: SymbolReference[] = [];
+
+    const ext = path.extname(relativePath).toLowerCase();
+    let scriptKind = ts.ScriptKind.TS;
+    if (ext === '.tsx' || ext === '.jsx') {
+      scriptKind = ts.ScriptKind.TSX;
+    } else if (['.js', '.mjs', '.cjs'].includes(ext)) {
+      scriptKind = ts.ScriptKind.JS;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      relativePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      scriptKind
+    );
+
+    const findIdentifiers = (node: ts.Node) => {
+      if (ts.isIdentifier(node) && node.text === symbolName) {
+        const line = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+        const column = sourceFile.getLineAndCharacterOfPosition(node.getStart()).character;
+
+        // Skip the definition itself
+        if (
+          relativePath === targetSymbol.location.filepath &&
+          line === targetSymbol.location.startLine
+        ) {
+          return;
+        }
+
+        // Get context (surrounding lines)
+        const startLine = Math.max(0, line - 2);
+        const endLine = Math.min(lines.length, line + 1);
+        const codeSnippet = lines.slice(startLine, endLine).join('\n');
+
+        // Create a minimal referencing symbol
+        const referencingSymbol: Symbol = {
+          name: symbolName,
+          namePath: `/${relativePath}:${line}`,
+          kind: SymbolKind.Variable, // Default - we don't have full context here
+          location: {
+            filepath: relativePath,
+            startLine: line,
+            endLine: line,
+            startColumn: column,
+            endColumn: column + symbolName.length,
+          },
+          depth: 0,
+        };
+
+        references.push({
+          referencingSymbol,
+          codeSnippet,
+          line,
+          column,
+        });
+      }
+
+      ts.forEachChild(node, findIdentifiers);
+    };
+
+    findIdentifiers(sourceFile);
+
+    return references;
+  }
+
+  private async findReferencesWithTreeSitter(
+    content: string,
+    _filepath: string,
+    relativePath: string,
+    lines: string[],
+    symbolName: string,
+    targetSymbol: Symbol,
+    config: LanguageConfig
+  ): Promise<SymbolReference[]> {
+    await ReferenceFinder.initialize();
+
+    const language = await ReferenceFinder.loadLanguage(config);
+    const parser = ReferenceFinder.parser;
+    if (!parser) {
+      return [];
+    }
+    parser.setLanguage(language);
+
+    const tree = parser.parse(content);
+    if (!tree) {
+      return [];
+    }
+
+    const references: SymbolReference[] = [];
+
+    const findIdentifiers = (node: SyntaxNode) => {
+      if (config.identifierTypes.includes(node.type) && node.text === symbolName) {
+        const line = node.startPosition.row + 1;
+        const column = node.startPosition.column;
+
+        // Skip the definition itself
+        if (
+          relativePath === targetSymbol.location.filepath &&
+          line >= targetSymbol.location.startLine &&
+          line <= targetSymbol.location.endLine
+        ) {
+          return;
+        }
+
+        // Get context (surrounding lines)
+        const startLine = Math.max(0, line - 2);
+        const endLine = Math.min(lines.length, line + 1);
+        const codeSnippet = lines.slice(startLine, endLine).join('\n');
+
+        const referencingSymbol: Symbol = {
+          name: symbolName,
+          namePath: `/${relativePath}:${line}`,
+          kind: SymbolKind.Variable,
+          location: {
+            filepath: relativePath,
+            startLine: line,
+            endLine: line,
+            startColumn: column,
+            endColumn: column + symbolName.length,
+          },
+          depth: 0,
+        };
+
+        references.push({
+          referencingSymbol,
+          codeSnippet,
+          line,
+          column,
+        });
+      }
+
+      for (const child of node.children) {
+        findIdentifiers(child);
+      }
+    };
+
+    findIdentifiers(tree.rootNode);
+
+    return references;
+  }
+}
+
+/**
+ * Format reference results for display.
+ */
+export function formatReferencesResult(references: SymbolReference[]): string {
+  if (references.length === 0) {
+    return 'No references found.';
+  }
+
+  const parts: string[] = [];
+  parts.push(`Found ${references.length} reference${references.length === 1 ? '' : 's'}:\n`);
+
+  // Group by file
+  const byFile = new Map<string, SymbolReference[]>();
+  for (const ref of references) {
+    const file = ref.referencingSymbol.location.filepath;
+    const fileRefs = byFile.get(file) || [];
+    fileRefs.push(ref);
+    byFile.set(file, fileRefs);
+  }
+
+  for (const [filepath, fileRefs] of byFile) {
+    parts.push(`\n## ${filepath}\n`);
+
+    for (const ref of fileRefs) {
+      parts.push(`Line ${ref.line}:`);
+      parts.push('```');
+      parts.push(ref.codeSnippet);
+      parts.push('```\n');
+    }
+  }
+
+  return parts.join('\n');
+}

--- a/src/symbols/symbol-editor.ts
+++ b/src/symbols/symbol-editor.ts
@@ -1,0 +1,337 @@
+/**
+ * Symbol editor for modifying symbol definitions in source files.
+ * Provides atomic operations to replace, insert before, or insert after symbols.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Symbol } from './types.js';
+import { SymbolExtractor } from './symbol-extractor.js';
+import { parseNamePath, matchNamePath, getSymbolName } from './name-path.js';
+
+/**
+ * Result from a symbol edit operation.
+ */
+export interface EditResult {
+  /** Whether the edit was successful */
+  success: boolean;
+  /** Updated file path */
+  filepath: string;
+  /** Symbol that was edited */
+  symbolName: string;
+  /** New line range of the edited content */
+  newRange?: { startLine: number; endLine: number };
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Options for replace_symbol_body.
+ */
+export interface ReplaceSymbolOptions {
+  /** Name path of the symbol to replace */
+  namePath: string;
+  /** Relative path to the file containing the symbol */
+  relativePath: string;
+  /** The new body content for the symbol */
+  body: string;
+}
+
+/**
+ * Options for insert_before_symbol or insert_after_symbol.
+ */
+export interface InsertSymbolOptions {
+  /** Name path of the reference symbol */
+  namePath: string;
+  /** Relative path to the file containing the symbol */
+  relativePath: string;
+  /** The content to insert */
+  body: string;
+}
+
+/**
+ * Symbol editor for modifying source files.
+ */
+export class SymbolEditor {
+  private projectPath: string;
+  private symbolExtractor: SymbolExtractor;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+    this.symbolExtractor = new SymbolExtractor(projectPath);
+  }
+
+  /**
+   * Replace a symbol's body with new content.
+   */
+  async replaceSymbolBody(options: ReplaceSymbolOptions): Promise<EditResult> {
+    const { namePath, relativePath, body } = options;
+    const fullPath = path.join(this.projectPath, relativePath);
+
+    try {
+      // Find the target symbol
+      const symbols = await this.symbolExtractor.extractSymbols(relativePath, true);
+      const pattern = parseNamePath(namePath);
+      const targetSymbol = this.findSymbolByPattern(symbols, pattern);
+
+      if (!targetSymbol) {
+        return {
+          success: false,
+          filepath: relativePath,
+          symbolName: getSymbolName(namePath),
+          error: `Symbol not found: ${namePath}`,
+        };
+      }
+
+      // Read the file
+      const content = await fs.readFile(fullPath, 'utf-8');
+      const lines = content.split('\n');
+
+      // Get the indentation of the original symbol
+      const originalFirstLine = lines[targetSymbol.location.startLine - 1];
+      const indentation = this.detectIndentation(originalFirstLine);
+
+      // Apply indentation to the new body
+      const indentedBody = this.applyIndentation(body, indentation);
+
+      // Replace the lines
+      const beforeLines = lines.slice(0, targetSymbol.location.startLine - 1);
+      const afterLines = lines.slice(targetSymbol.location.endLine);
+      const newBodyLines = indentedBody.split('\n');
+
+      const newContent = [...beforeLines, ...newBodyLines, ...afterLines].join('\n');
+
+      // Write the file atomically
+      await this.atomicWrite(fullPath, newContent);
+
+      return {
+        success: true,
+        filepath: relativePath,
+        symbolName: targetSymbol.name,
+        newRange: {
+          startLine: targetSymbol.location.startLine,
+          endLine: targetSymbol.location.startLine + newBodyLines.length - 1,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        filepath: relativePath,
+        symbolName: getSymbolName(namePath),
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Insert content before a symbol.
+   */
+  async insertBeforeSymbol(options: InsertSymbolOptions): Promise<EditResult> {
+    const { namePath, relativePath, body } = options;
+    const fullPath = path.join(this.projectPath, relativePath);
+
+    try {
+      // Find the target symbol
+      const symbols = await this.symbolExtractor.extractSymbols(relativePath, false);
+      const pattern = parseNamePath(namePath);
+      const targetSymbol = this.findSymbolByPattern(symbols, pattern);
+
+      if (!targetSymbol) {
+        return {
+          success: false,
+          filepath: relativePath,
+          symbolName: getSymbolName(namePath),
+          error: `Symbol not found: ${namePath}`,
+        };
+      }
+
+      // Read the file
+      const content = await fs.readFile(fullPath, 'utf-8');
+      const lines = content.split('\n');
+
+      // Get the indentation of the target symbol
+      const originalFirstLine = lines[targetSymbol.location.startLine - 1];
+      const indentation = this.detectIndentation(originalFirstLine);
+
+      // Apply indentation to the new body
+      const indentedBody = this.applyIndentation(body, indentation);
+      const newBodyLines = indentedBody.split('\n');
+
+      // Insert before the symbol (add blank line after if not present)
+      const insertPoint = targetSymbol.location.startLine - 1;
+      const beforeLines = lines.slice(0, insertPoint);
+      const afterLines = lines.slice(insertPoint);
+
+      // Add a blank line between new content and existing symbol if needed
+      const needsBlankLine =
+        newBodyLines.length > 0 && afterLines.length > 0 && afterLines[0].trim() !== '';
+      const separator = needsBlankLine ? [''] : [];
+
+      const newContent = [...beforeLines, ...newBodyLines, ...separator, ...afterLines].join('\n');
+
+      // Write the file atomically
+      await this.atomicWrite(fullPath, newContent);
+
+      return {
+        success: true,
+        filepath: relativePath,
+        symbolName: targetSymbol.name,
+        newRange: {
+          startLine: insertPoint + 1,
+          endLine: insertPoint + newBodyLines.length,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        filepath: relativePath,
+        symbolName: getSymbolName(namePath),
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Insert content after a symbol.
+   */
+  async insertAfterSymbol(options: InsertSymbolOptions): Promise<EditResult> {
+    const { namePath, relativePath, body } = options;
+    const fullPath = path.join(this.projectPath, relativePath);
+
+    try {
+      // Find the target symbol
+      const symbols = await this.symbolExtractor.extractSymbols(relativePath, false);
+      const pattern = parseNamePath(namePath);
+      const targetSymbol = this.findSymbolByPattern(symbols, pattern);
+
+      if (!targetSymbol) {
+        return {
+          success: false,
+          filepath: relativePath,
+          symbolName: getSymbolName(namePath),
+          error: `Symbol not found: ${namePath}`,
+        };
+      }
+
+      // Read the file
+      const content = await fs.readFile(fullPath, 'utf-8');
+      const lines = content.split('\n');
+
+      // Get the indentation of the target symbol
+      const originalFirstLine = lines[targetSymbol.location.startLine - 1];
+      const indentation = this.detectIndentation(originalFirstLine);
+
+      // Apply indentation to the new body
+      const indentedBody = this.applyIndentation(body, indentation);
+      const newBodyLines = indentedBody.split('\n');
+
+      // Insert after the symbol
+      const insertPoint = targetSymbol.location.endLine;
+      const beforeLines = lines.slice(0, insertPoint);
+      const afterLines = lines.slice(insertPoint);
+
+      // Add a blank line before new content if needed
+      const needsBlankLine =
+        beforeLines.length > 0 && beforeLines[beforeLines.length - 1].trim() !== '';
+      const separator = needsBlankLine ? [''] : [];
+
+      const newContent = [...beforeLines, ...separator, ...newBodyLines, ...afterLines].join('\n');
+
+      // Write the file atomically
+      await this.atomicWrite(fullPath, newContent);
+
+      return {
+        success: true,
+        filepath: relativePath,
+        symbolName: targetSymbol.name,
+        newRange: {
+          startLine: insertPoint + separator.length + 1,
+          endLine: insertPoint + separator.length + newBodyLines.length,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        filepath: relativePath,
+        symbolName: getSymbolName(namePath),
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Find a symbol by name path pattern.
+   */
+  private findSymbolByPattern(
+    symbols: Symbol[],
+    pattern: ReturnType<typeof parseNamePath>
+  ): Symbol | null {
+    for (const symbol of symbols) {
+      if (matchNamePath(symbol.namePath, pattern)) {
+        return symbol;
+      }
+      if (symbol.children) {
+        const found = this.findSymbolByPattern(symbol.children, pattern);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Detect the indentation used on a line.
+   */
+  private detectIndentation(line: string): string {
+    const match = line.match(/^(\s*)/);
+    return match ? match[1] : '';
+  }
+
+  /**
+   * Apply indentation to a block of code.
+   */
+  private applyIndentation(code: string, baseIndentation: string): string {
+    const lines = code.split('\n');
+
+    // Find the minimum indentation in the provided code (excluding empty lines)
+    let minIndent = Infinity;
+    for (const line of lines) {
+      if (line.trim().length > 0) {
+        const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+        minIndent = Math.min(minIndent, indent);
+      }
+    }
+    if (minIndent === Infinity) minIndent = 0;
+
+    // Re-indent the code with the base indentation
+    return lines
+      .map((line) => {
+        if (line.trim().length === 0) {
+          return '';
+        }
+        const relativeIndent = line.substring(minIndent);
+        return baseIndentation + relativeIndent;
+      })
+      .join('\n');
+  }
+
+  /**
+   * Write a file atomically (write to temp file, then rename).
+   */
+  private async atomicWrite(filepath: string, content: string): Promise<void> {
+    const tempPath = `${filepath}.tmp.${Date.now()}`;
+    try {
+      await fs.writeFile(tempPath, content, 'utf-8');
+      await fs.rename(tempPath, filepath);
+    } catch (error) {
+      // Try to clean up temp file
+      try {
+        await fs.unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+}

--- a/src/symbols/symbol-extractor.ts
+++ b/src/symbols/symbol-extractor.ts
@@ -1,0 +1,813 @@
+/**
+ * Symbol extractor using Tree-sitter and TypeScript AST for multiple languages.
+ * Extracts hierarchical symbol information from source files.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as ts from 'typescript';
+import type { Parser as ParserType, Language, Node as SyntaxNode } from 'web-tree-sitter';
+import {
+  Symbol,
+  SymbolKind,
+  SymbolLocation,
+  SymbolsOverview,
+  SymbolOverviewEntry,
+  SymbolKindNames,
+} from './types.js';
+import { buildNamePath, formatNamePath } from './name-path.js';
+
+// Dynamic import for ESM compatibility
+interface ParserModule {
+  Parser: typeof ParserType;
+  Language: typeof Language;
+}
+
+let parserModule: ParserModule | null = null;
+const loadParserModule = async (): Promise<ParserModule> => {
+  if (!parserModule) {
+    const mod = await import('web-tree-sitter');
+    parserModule = {
+      Parser: mod.Parser,
+      Language: mod.Language,
+    };
+  }
+  return parserModule;
+};
+
+/**
+ * Language configuration for symbol extraction
+ */
+interface LanguageConfig {
+  wasmFile: string;
+  extensions: string[];
+  // Node types for different symbol kinds
+  functionTypes: string[];
+  classTypes: string[];
+  methodTypes: string[];
+  importTypes: string[];
+  variableTypes: string[];
+  interfaceTypes: string[];
+  typeTypes: string[];
+  constructorTypes: string[];
+}
+
+/**
+ * Language configurations (same as TreeSitterChunker but with constructor types)
+ */
+const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
+  python: {
+    wasmFile: 'tree-sitter-python.wasm',
+    extensions: ['.py', '.pyi'],
+    functionTypes: ['function_definition'],
+    classTypes: ['class_definition'],
+    methodTypes: ['function_definition'],
+    importTypes: ['import_statement', 'import_from_statement'],
+    variableTypes: ['assignment', 'expression_statement'],
+    interfaceTypes: [],
+    typeTypes: [],
+    constructorTypes: [], // __init__ is detected by name
+  },
+  go: {
+    wasmFile: 'tree-sitter-go.wasm',
+    extensions: ['.go'],
+    functionTypes: ['function_declaration'],
+    classTypes: [],
+    methodTypes: ['method_declaration'],
+    importTypes: ['import_declaration'],
+    variableTypes: ['var_declaration', 'const_declaration', 'short_var_declaration'],
+    interfaceTypes: ['type_declaration'],
+    typeTypes: ['type_declaration'],
+    constructorTypes: [],
+  },
+  rust: {
+    wasmFile: 'tree-sitter-rust.wasm',
+    extensions: ['.rs'],
+    functionTypes: ['function_item'],
+    classTypes: [],
+    methodTypes: ['function_item'],
+    importTypes: ['use_declaration'],
+    variableTypes: ['let_declaration', 'const_item', 'static_item'],
+    interfaceTypes: ['trait_item'],
+    typeTypes: ['type_item', 'struct_item', 'enum_item', 'impl_item'],
+    constructorTypes: [],
+  },
+  java: {
+    wasmFile: 'tree-sitter-java.wasm',
+    extensions: ['.java'],
+    functionTypes: [],
+    classTypes: ['class_declaration', 'interface_declaration', 'enum_declaration'],
+    methodTypes: ['method_declaration'],
+    importTypes: ['import_declaration'],
+    variableTypes: ['field_declaration', 'local_variable_declaration'],
+    interfaceTypes: ['interface_declaration'],
+    typeTypes: [],
+    constructorTypes: ['constructor_declaration'],
+  },
+  ruby: {
+    wasmFile: 'tree-sitter-ruby.wasm',
+    extensions: ['.rb'],
+    functionTypes: ['method'],
+    classTypes: ['class', 'module'],
+    methodTypes: ['method', 'singleton_method'],
+    importTypes: ['call'],
+    variableTypes: ['assignment'],
+    interfaceTypes: [],
+    typeTypes: [],
+    constructorTypes: [], // initialize is detected by name
+  },
+};
+
+/**
+ * Symbol extractor for extracting hierarchical symbol information.
+ */
+export class SymbolExtractor {
+  private static parser: ParserType | null = null;
+  private static loadedLanguages: Map<string, Language> = new Map();
+  private static initPromise: Promise<void> | null = null;
+  private static wasmBasePath: string | null = null;
+
+  private projectPath: string;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+  }
+
+  /**
+   * Initialize the tree-sitter parser.
+   */
+  private static async initialize(): Promise<void> {
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = (async () => {
+      this.wasmBasePath = await this.findWasmBasePath();
+      const module = await loadParserModule();
+
+      const webTreeSitterWasm = path.join(
+        process.cwd(),
+        'node_modules',
+        'web-tree-sitter',
+        'web-tree-sitter.wasm'
+      );
+      await module.Parser.init({
+        locateFile: () => webTreeSitterWasm,
+      });
+      this.parser = new module.Parser();
+    })();
+
+    return this.initPromise;
+  }
+
+  private static async findWasmBasePath(): Promise<string> {
+    const { fileURLToPath } = await import('url');
+    const possiblePaths = [
+      path.join(process.cwd(), 'node_modules', '@vscode', 'tree-sitter-wasm', 'wasm'),
+      path.join(
+        fileURLToPath(import.meta.url),
+        '..',
+        '..',
+        '..',
+        'node_modules',
+        '@vscode',
+        'tree-sitter-wasm',
+        'wasm'
+      ),
+    ];
+
+    for (const p of possiblePaths) {
+      try {
+        await fs.access(p);
+        return p;
+      } catch {
+        // Try next path
+      }
+    }
+
+    throw new Error(
+      'Could not find @vscode/tree-sitter-wasm package. Please install it with: npm install @vscode/tree-sitter-wasm'
+    );
+  }
+
+  private static getLanguageConfig(filepath: string): LanguageConfig | null {
+    const ext = path.extname(filepath).toLowerCase();
+    for (const [, config] of Object.entries(LANGUAGE_CONFIGS)) {
+      if (config.extensions.includes(ext)) {
+        return config;
+      }
+    }
+    return null;
+  }
+
+  private static async loadLanguage(config: LanguageConfig): Promise<Language> {
+    const cached = this.loadedLanguages.get(config.wasmFile);
+    if (cached) {
+      return cached;
+    }
+
+    if (!this.wasmBasePath) {
+      throw new Error('SymbolExtractor not initialized.');
+    }
+
+    const module = await loadParserModule();
+    const wasmPath = path.join(this.wasmBasePath, config.wasmFile);
+    const wasmBytes = await fs.readFile(wasmPath);
+    const language = await module.Language.load(wasmBytes);
+    this.loadedLanguages.set(config.wasmFile, language);
+    return language;
+  }
+
+  /**
+   * Check if a file can be analyzed for symbols.
+   */
+  static canAnalyze(filepath: string): boolean {
+    const ext = path.extname(filepath).toLowerCase();
+    // TypeScript/JavaScript via TS compiler
+    if (['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'].includes(ext)) {
+      return true;
+    }
+    // Other languages via tree-sitter
+    return this.getLanguageConfig(filepath) !== null;
+  }
+
+  /**
+   * Extract all symbols from a file.
+   */
+  async extractSymbols(filepath: string, includeBody: boolean = false): Promise<Symbol[]> {
+    const fullPath = path.isAbsolute(filepath) ? filepath : path.join(this.projectPath, filepath);
+    const relativePath = path.isAbsolute(filepath)
+      ? path.relative(this.projectPath, filepath)
+      : filepath;
+
+    const ext = path.extname(fullPath).toLowerCase();
+
+    // Use TypeScript compiler for TS/JS files
+    if (['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'].includes(ext)) {
+      return this.extractSymbolsWithTypeScript(fullPath, relativePath, includeBody);
+    }
+
+    // Use tree-sitter for other languages
+    const config = SymbolExtractor.getLanguageConfig(fullPath);
+    if (config) {
+      return this.extractSymbolsWithTreeSitter(fullPath, relativePath, config, includeBody);
+    }
+
+    throw new Error(`Unsupported file type: ${filepath}`);
+  }
+
+  /**
+   * Get symbols overview for a file.
+   */
+  async getSymbolsOverview(filepath: string, depth: number = 0): Promise<SymbolsOverview> {
+    const symbols = await this.extractSymbols(filepath, false);
+    const relativePath = path.isAbsolute(filepath)
+      ? path.relative(this.projectPath, filepath)
+      : filepath;
+
+    // Group by kind
+    const byKind: Record<string, SymbolOverviewEntry[]> = {};
+
+    const processSymbol = (symbol: Symbol, currentDepth: number) => {
+      const kindName = SymbolKindNames[symbol.kind];
+      if (!byKind[kindName]) {
+        byKind[kindName] = [];
+      }
+
+      byKind[kindName].push({
+        name: symbol.name,
+        namePath: formatNamePath(symbol.namePath),
+        lines: `${symbol.location.startLine}-${symbol.location.endLine}`,
+        children: symbol.children?.length,
+      });
+
+      // Process children up to requested depth
+      if (currentDepth < depth && symbol.children) {
+        for (const child of symbol.children) {
+          processSymbol(child, currentDepth + 1);
+        }
+      }
+    };
+
+    for (const symbol of symbols) {
+      processSymbol(symbol, 0);
+    }
+
+    return {
+      filepath: relativePath,
+      byKind,
+      totalSymbols: this.countSymbols(symbols, depth),
+    };
+  }
+
+  private countSymbols(symbols: Symbol[], depth: number, currentDepth: number = 0): number {
+    let count = symbols.length;
+    if (currentDepth < depth) {
+      for (const symbol of symbols) {
+        if (symbol.children) {
+          count += this.countSymbols(symbol.children, depth, currentDepth + 1);
+        }
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Extract symbols using TypeScript compiler.
+   */
+  private async extractSymbolsWithTypeScript(
+    fullPath: string,
+    relativePath: string,
+    includeBody: boolean
+  ): Promise<Symbol[]> {
+    const content = await fs.readFile(fullPath, 'utf-8');
+    const ext = path.extname(fullPath).toLowerCase();
+
+    let scriptKind = ts.ScriptKind.TS;
+    if (ext === '.tsx' || ext === '.jsx') {
+      scriptKind = ts.ScriptKind.TSX;
+    } else if (['.js', '.mjs', '.cjs'].includes(ext)) {
+      scriptKind = ts.ScriptKind.JS;
+    }
+
+    const sourceFile = ts.createSourceFile(
+      fullPath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      scriptKind
+    );
+
+    const lines = content.split('\n');
+    const symbols: Symbol[] = [];
+
+    const processNode = (
+      node: ts.Node,
+      parentPath: string | undefined,
+      parentDepth: number
+    ): void => {
+      // Skip import/export declarations
+      if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+        return;
+      }
+
+      const symbol = this.nodeToSymbol(
+        node,
+        sourceFile,
+        lines,
+        relativePath,
+        parentPath,
+        parentDepth,
+        includeBody
+      );
+      if (symbol) {
+        symbols.push(symbol);
+
+        // Process children for classes
+        if (ts.isClassDeclaration(node)) {
+          const children: Symbol[] = [];
+          node.members.forEach((member) => {
+            const childSymbol = this.memberToSymbol(
+              member,
+              sourceFile,
+              lines,
+              relativePath,
+              symbol.namePath,
+              symbol.depth + 1,
+              includeBody
+            );
+            if (childSymbol) {
+              children.push(childSymbol);
+            }
+          });
+          if (children.length > 0) {
+            symbol.children = children;
+          }
+        }
+      } else {
+        // Process children for non-symbol nodes
+        ts.forEachChild(node, (child) => processNode(child, parentPath, parentDepth));
+      }
+    };
+
+    ts.forEachChild(sourceFile, (node) => processNode(node, undefined, 0));
+
+    return symbols;
+  }
+
+  private nodeToSymbol(
+    node: ts.Node,
+    sourceFile: ts.SourceFile,
+    lines: string[],
+    relativePath: string,
+    parentPath: string | undefined,
+    depth: number,
+    includeBody: boolean
+  ): Symbol | null {
+    const fullStart = node.getFullStart();
+    const startLine = sourceFile.getLineAndCharacterOfPosition(fullStart).line + 1;
+    const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line + 1;
+    const startChar = sourceFile.getLineAndCharacterOfPosition(node.getStart()).character;
+    const endChar = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).character;
+
+    let name: string | undefined;
+    let kind: SymbolKind;
+
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      name = node.name.getText(sourceFile);
+      kind = SymbolKind.Function;
+    } else if (ts.isClassDeclaration(node) && node.name) {
+      name = node.name.getText(sourceFile);
+      kind = SymbolKind.Class;
+    } else if (ts.isInterfaceDeclaration(node)) {
+      name = node.name.getText(sourceFile);
+      kind = SymbolKind.Interface;
+    } else if (ts.isTypeAliasDeclaration(node)) {
+      name = node.name.getText(sourceFile);
+      kind = SymbolKind.TypeParameter;
+    } else if (ts.isEnumDeclaration(node)) {
+      name = node.name.getText(sourceFile);
+      kind = SymbolKind.Enum;
+    } else if (ts.isVariableStatement(node)) {
+      const declarations = node.declarationList.declarations;
+      if (declarations.length > 0 && ts.isIdentifier(declarations[0].name)) {
+        name = declarations[0].name.getText(sourceFile);
+        kind =
+          ts.getCombinedModifierFlags(declarations[0]) & ts.ModifierFlags.Const
+            ? SymbolKind.Constant
+            : SymbolKind.Variable;
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+
+    if (!name) {
+      return null;
+    }
+
+    const namePath = buildNamePath(parentPath, name);
+    const location: SymbolLocation = {
+      filepath: relativePath,
+      startLine,
+      endLine,
+      startColumn: startChar,
+      endColumn: endChar,
+    };
+
+    const symbol: Symbol = {
+      name,
+      namePath,
+      kind,
+      location,
+      depth,
+      parentNamePath: parentPath,
+    };
+
+    if (includeBody) {
+      symbol.body = lines.slice(startLine - 1, endLine).join('\n');
+    }
+
+    return symbol;
+  }
+
+  private memberToSymbol(
+    member: ts.ClassElement,
+    sourceFile: ts.SourceFile,
+    lines: string[],
+    relativePath: string,
+    parentPath: string,
+    depth: number,
+    includeBody: boolean
+  ): Symbol | null {
+    const fullStart = member.getFullStart();
+    const startLine = sourceFile.getLineAndCharacterOfPosition(fullStart).line + 1;
+    const endLine = sourceFile.getLineAndCharacterOfPosition(member.getEnd()).line + 1;
+    const startChar = sourceFile.getLineAndCharacterOfPosition(member.getStart()).character;
+    const endChar = sourceFile.getLineAndCharacterOfPosition(member.getEnd()).character;
+
+    let name: string | undefined;
+    let kind: SymbolKind;
+
+    if (
+      ts.isMethodDeclaration(member) ||
+      ts.isGetAccessorDeclaration(member) ||
+      ts.isSetAccessorDeclaration(member)
+    ) {
+      name = member.name?.getText(sourceFile);
+      kind = SymbolKind.Method;
+    } else if (ts.isConstructorDeclaration(member)) {
+      name = 'constructor';
+      kind = SymbolKind.Constructor;
+    } else if (ts.isPropertyDeclaration(member)) {
+      name = member.name?.getText(sourceFile);
+      kind = SymbolKind.Property;
+    } else {
+      return null;
+    }
+
+    if (!name) {
+      return null;
+    }
+
+    const namePath = buildNamePath(parentPath, name);
+    const location: SymbolLocation = {
+      filepath: relativePath,
+      startLine,
+      endLine,
+      startColumn: startChar,
+      endColumn: endChar,
+    };
+
+    const symbol: Symbol = {
+      name,
+      namePath,
+      kind,
+      location,
+      depth,
+      parentNamePath: parentPath,
+    };
+
+    if (includeBody) {
+      symbol.body = lines.slice(startLine - 1, endLine).join('\n');
+    }
+
+    return symbol;
+  }
+
+  /**
+   * Extract symbols using tree-sitter.
+   */
+  private async extractSymbolsWithTreeSitter(
+    fullPath: string,
+    relativePath: string,
+    config: LanguageConfig,
+    includeBody: boolean
+  ): Promise<Symbol[]> {
+    await SymbolExtractor.initialize();
+
+    const language = await SymbolExtractor.loadLanguage(config);
+    const parser = SymbolExtractor.parser;
+    if (!parser) {
+      throw new Error('SymbolExtractor parser not initialized');
+    }
+    parser.setLanguage(language);
+
+    const content = await fs.readFile(fullPath, 'utf-8');
+    const tree = parser.parse(content);
+    if (!tree) {
+      throw new Error(`Failed to parse file: ${fullPath}`);
+    }
+
+    const lines = content.split('\n');
+    const symbols: Symbol[] = [];
+
+    this.processTreeSitterNode(
+      tree.rootNode,
+      config,
+      lines,
+      relativePath,
+      undefined,
+      0,
+      symbols,
+      includeBody
+    );
+
+    return symbols;
+  }
+
+  private processTreeSitterNode(
+    node: SyntaxNode,
+    config: LanguageConfig,
+    lines: string[],
+    relativePath: string,
+    parentPath: string | undefined,
+    depth: number,
+    symbols: Symbol[],
+    includeBody: boolean,
+    parentClassName?: string
+  ): void {
+    // Check for classes
+    if (config.classTypes.includes(node.type)) {
+      const name = this.getTreeSitterNodeName(node) || 'AnonymousClass';
+      const namePath = buildNamePath(parentPath, name);
+
+      const symbol: Symbol = {
+        name,
+        namePath,
+        kind: SymbolKind.Class,
+        location: {
+          filepath: relativePath,
+          startLine: node.startPosition.row + 1,
+          endLine: node.endPosition.row + 1,
+          startColumn: node.startPosition.column,
+          endColumn: node.endPosition.column,
+        },
+        depth,
+        parentNamePath: parentPath,
+        children: [],
+      };
+
+      if (includeBody) {
+        symbol.body = lines.slice(node.startPosition.row, node.endPosition.row + 1).join('\n');
+      }
+
+      // Process class children
+      const symbolChildren = symbol.children || [];
+      for (const child of node.children) {
+        this.processTreeSitterNode(
+          child,
+          config,
+          lines,
+          relativePath,
+          namePath,
+          depth + 1,
+          symbolChildren,
+          includeBody,
+          name
+        );
+      }
+
+      if (symbolChildren.length === 0) {
+        delete symbol.children;
+      } else {
+        symbol.children = symbolChildren;
+      }
+
+      symbols.push(symbol);
+      return;
+    }
+
+    // Check for functions (top-level)
+    if (config.functionTypes.includes(node.type) && !parentClassName) {
+      const name = this.getTreeSitterNodeName(node);
+      if (name) {
+        const namePath = buildNamePath(parentPath, name);
+
+        const symbol: Symbol = {
+          name,
+          namePath,
+          kind: SymbolKind.Function,
+          location: {
+            filepath: relativePath,
+            startLine: node.startPosition.row + 1,
+            endLine: node.endPosition.row + 1,
+            startColumn: node.startPosition.column,
+            endColumn: node.endPosition.column,
+          },
+          depth,
+          parentNamePath: parentPath,
+        };
+
+        if (includeBody) {
+          symbol.body = lines.slice(node.startPosition.row, node.endPosition.row + 1).join('\n');
+        }
+
+        symbols.push(symbol);
+        return;
+      }
+    }
+
+    // Check for methods (inside class)
+    if (config.methodTypes.includes(node.type) && parentClassName) {
+      const name = this.getTreeSitterNodeName(node);
+      if (name) {
+        const namePath = buildNamePath(parentPath, name);
+
+        // Determine if constructor
+        const isConstructor =
+          config.constructorTypes.includes(node.type) ||
+          name === '__init__' ||
+          name === 'initialize' ||
+          name === 'constructor';
+
+        const symbol: Symbol = {
+          name,
+          namePath,
+          kind: isConstructor ? SymbolKind.Constructor : SymbolKind.Method,
+          location: {
+            filepath: relativePath,
+            startLine: node.startPosition.row + 1,
+            endLine: node.endPosition.row + 1,
+            startColumn: node.startPosition.column,
+            endColumn: node.endPosition.column,
+          },
+          depth,
+          parentNamePath: parentPath,
+        };
+
+        if (includeBody) {
+          symbol.body = lines.slice(node.startPosition.row, node.endPosition.row + 1).join('\n');
+        }
+
+        symbols.push(symbol);
+        return;
+      }
+    }
+
+    // Check for interfaces/traits
+    if (config.interfaceTypes.includes(node.type)) {
+      const name = this.getTreeSitterNodeName(node);
+      if (name) {
+        const namePath = buildNamePath(parentPath, name);
+
+        const symbol: Symbol = {
+          name,
+          namePath,
+          kind: SymbolKind.Interface,
+          location: {
+            filepath: relativePath,
+            startLine: node.startPosition.row + 1,
+            endLine: node.endPosition.row + 1,
+            startColumn: node.startPosition.column,
+            endColumn: node.endPosition.column,
+          },
+          depth,
+          parentNamePath: parentPath,
+        };
+
+        if (includeBody) {
+          symbol.body = lines.slice(node.startPosition.row, node.endPosition.row + 1).join('\n');
+        }
+
+        symbols.push(symbol);
+        return;
+      }
+    }
+
+    // Check for top-level variables
+    if (
+      config.variableTypes.includes(node.type) &&
+      (node.parent?.type === 'source_file' || node.parent?.type === 'program')
+    ) {
+      const name = this.getTreeSitterNodeName(node);
+      if (name) {
+        const namePath = buildNamePath(parentPath, name);
+
+        const symbol: Symbol = {
+          name,
+          namePath,
+          kind: SymbolKind.Variable,
+          location: {
+            filepath: relativePath,
+            startLine: node.startPosition.row + 1,
+            endLine: node.endPosition.row + 1,
+            startColumn: node.startPosition.column,
+            endColumn: node.endPosition.column,
+          },
+          depth,
+          parentNamePath: parentPath,
+        };
+
+        if (includeBody) {
+          symbol.body = lines.slice(node.startPosition.row, node.endPosition.row + 1).join('\n');
+        }
+
+        symbols.push(symbol);
+        return;
+      }
+    }
+
+    // Recurse into children for other node types
+    for (const child of node.children) {
+      this.processTreeSitterNode(
+        child,
+        config,
+        lines,
+        relativePath,
+        parentPath,
+        depth,
+        symbols,
+        includeBody,
+        parentClassName
+      );
+    }
+  }
+
+  private getTreeSitterNodeName(node: SyntaxNode): string | undefined {
+    // Look for name/identifier child
+    for (const child of node.children) {
+      if (
+        child.type === 'identifier' ||
+        child.type === 'name' ||
+        child.type === 'type_identifier'
+      ) {
+        return child.text;
+      }
+      if (child.type === 'decorated_definition') {
+        return this.getTreeSitterNodeName(child);
+      }
+    }
+
+    const firstNamedChild = node.firstNamedChild;
+    if (
+      firstNamedChild &&
+      (firstNamedChild.type === 'identifier' || firstNamedChild.type === 'name')
+    ) {
+      return firstNamedChild.text;
+    }
+
+    return undefined;
+  }
+}

--- a/src/symbols/symbol-renamer.ts
+++ b/src/symbols/symbol-renamer.ts
@@ -1,0 +1,285 @@
+/**
+ * Symbol renamer for renaming symbols across the codebase.
+ * Uses text-based replacement with reference finding for cross-file renames.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Symbol } from './types.js';
+import { SymbolExtractor } from './symbol-extractor.js';
+import { ReferenceFinder } from './reference-finder.js';
+import { parseNamePath, matchNamePath, getSymbolName } from './name-path.js';
+
+/**
+ * Result from a rename operation.
+ */
+export interface RenameResult {
+  /** Whether the rename was successful */
+  success: boolean;
+  /** Original symbol name */
+  originalName: string;
+  /** New symbol name */
+  newName: string;
+  /** Files that were modified */
+  modifiedFiles: RenameFileResult[];
+  /** Total number of replacements made */
+  totalReplacements: number;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Result for a single file in a rename operation.
+ */
+export interface RenameFileResult {
+  /** Relative path to the file */
+  filepath: string;
+  /** Number of replacements made in this file */
+  replacements: number;
+}
+
+/**
+ * Options for rename_symbol.
+ */
+export interface RenameSymbolOptions {
+  /** Name path of the symbol to rename */
+  namePath: string;
+  /** Relative path to the file containing the symbol definition */
+  relativePath: string;
+  /** The new name for the symbol */
+  newName: string;
+  /** Whether to perform a dry run (preview without making changes) */
+  dryRun?: boolean;
+}
+
+/**
+ * Symbol renamer for cross-file symbol renaming.
+ */
+export class SymbolRenamer {
+  private projectPath: string;
+  private symbolExtractor: SymbolExtractor;
+  private referenceFinder: ReferenceFinder;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+    this.symbolExtractor = new SymbolExtractor(projectPath);
+    this.referenceFinder = new ReferenceFinder(projectPath);
+  }
+
+  /**
+   * Rename a symbol across the codebase.
+   */
+  async renameSymbol(options: RenameSymbolOptions): Promise<RenameResult> {
+    const { namePath, relativePath, newName, dryRun = false } = options;
+
+    try {
+      // Validate new name
+      if (!this.isValidIdentifier(newName)) {
+        return {
+          success: false,
+          originalName: getSymbolName(namePath),
+          newName,
+          modifiedFiles: [],
+          totalReplacements: 0,
+          error: `Invalid identifier: ${newName}`,
+        };
+      }
+
+      // Find the target symbol
+      const symbols = await this.symbolExtractor.extractSymbols(relativePath, false);
+      const pattern = parseNamePath(namePath);
+      const targetSymbol = this.findSymbolByPattern(symbols, pattern);
+
+      if (!targetSymbol) {
+        return {
+          success: false,
+          originalName: getSymbolName(namePath),
+          newName,
+          modifiedFiles: [],
+          totalReplacements: 0,
+          error: `Symbol not found: ${namePath} in ${relativePath}`,
+        };
+      }
+
+      const originalName = targetSymbol.name;
+
+      // Find all references to this symbol
+      const references = await this.referenceFinder.findReferences({
+        namePath,
+        relativePath,
+        includeInfo: false,
+      });
+
+      // Group replacements by file
+      const replacementsByFile = new Map<string, Set<number>>();
+
+      // Helper to get or create set for a file
+      const getFileSet = (file: string): Set<number> => {
+        let set = replacementsByFile.get(file);
+        if (!set) {
+          set = new Set();
+          replacementsByFile.set(file, set);
+        }
+        return set;
+      };
+
+      // Add the definition location
+      getFileSet(relativePath).add(targetSymbol.location.startLine);
+
+      // Add all reference locations
+      for (const ref of references) {
+        const file = ref.referencingSymbol.location.filepath;
+        getFileSet(file).add(ref.line);
+      }
+
+      const modifiedFiles: RenameFileResult[] = [];
+      let totalReplacements = 0;
+
+      // Perform replacements
+      for (const [file, lines] of replacementsByFile) {
+        const result = await this.replaceInFile(file, originalName, newName, lines, dryRun);
+        if (result.replacements > 0) {
+          modifiedFiles.push({
+            filepath: file,
+            replacements: result.replacements,
+          });
+          totalReplacements += result.replacements;
+        }
+      }
+
+      return {
+        success: true,
+        originalName,
+        newName,
+        modifiedFiles,
+        totalReplacements,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        originalName: getSymbolName(namePath),
+        newName,
+        modifiedFiles: [],
+        totalReplacements: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Check if a string is a valid identifier.
+   */
+  private isValidIdentifier(name: string): boolean {
+    // Basic identifier validation - starts with letter/underscore, followed by alphanumeric/underscore
+    return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name);
+  }
+
+  /**
+   * Find a symbol by name path pattern.
+   */
+  private findSymbolByPattern(
+    symbols: Symbol[],
+    pattern: ReturnType<typeof parseNamePath>
+  ): Symbol | null {
+    for (const symbol of symbols) {
+      if (matchNamePath(symbol.namePath, pattern)) {
+        return symbol;
+      }
+      if (symbol.children) {
+        const found = this.findSymbolByPattern(symbol.children, pattern);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Replace occurrences in a file on specific lines.
+   */
+  private async replaceInFile(
+    relativePath: string,
+    originalName: string,
+    newName: string,
+    targetLines: Set<number>,
+    dryRun: boolean
+  ): Promise<{ replacements: number }> {
+    const fullPath = path.join(this.projectPath, relativePath);
+    const content = await fs.readFile(fullPath, 'utf-8');
+    const lines = content.split('\n');
+
+    let replacements = 0;
+    const newLines = lines.map((line, index) => {
+      const lineNumber = index + 1;
+
+      // Only replace on target lines (where we found references)
+      if (!targetLines.has(lineNumber)) {
+        return line;
+      }
+
+      // Use word boundary matching to avoid partial replacements
+      const regex = new RegExp(`\\b${this.escapeRegex(originalName)}\\b`, 'g');
+      const newLine = line.replace(regex, () => {
+        replacements++;
+        return newName;
+      });
+
+      return newLine;
+    });
+
+    if (replacements > 0 && !dryRun) {
+      const newContent = newLines.join('\n');
+      await this.atomicWrite(fullPath, newContent);
+    }
+
+    return { replacements };
+  }
+
+  /**
+   * Escape special regex characters in a string.
+   */
+  private escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * Write a file atomically.
+   */
+  private async atomicWrite(filepath: string, content: string): Promise<void> {
+    const tempPath = `${filepath}.tmp.${Date.now()}`;
+    try {
+      await fs.writeFile(tempPath, content, 'utf-8');
+      await fs.rename(tempPath, filepath);
+    } catch (error) {
+      try {
+        await fs.unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+}
+
+/**
+ * Format rename result for display.
+ */
+export function formatRenameResult(result: RenameResult): string {
+  if (!result.success) {
+    return `Rename failed: ${result.error}`;
+  }
+
+  const parts: string[] = [];
+  parts.push(`Renamed "${result.originalName}" to "${result.newName}"`);
+  parts.push(`Total replacements: ${result.totalReplacements}`);
+  parts.push('\nModified files:');
+
+  for (const file of result.modifiedFiles) {
+    parts.push(
+      `- ${file.filepath} (${file.replacements} replacement${file.replacements === 1 ? '' : 's'})`
+    );
+  }
+
+  return parts.join('\n');
+}

--- a/src/symbols/types.ts
+++ b/src/symbols/types.ts
@@ -1,0 +1,314 @@
+/**
+ * Symbol types and interfaces for Serena-like symbolic code analysis.
+ * Uses LSP-compatible symbol kinds for interoperability.
+ */
+
+/**
+ * LSP-compatible symbol kinds.
+ * Based on the Language Server Protocol specification.
+ * @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind
+ */
+export enum SymbolKind {
+  File = 1,
+  Module = 2,
+  Namespace = 3,
+  Package = 4,
+  Class = 5,
+  Method = 6,
+  Property = 7,
+  Field = 8,
+  Constructor = 9,
+  Enum = 10,
+  Interface = 11,
+  Function = 12,
+  Variable = 13,
+  Constant = 14,
+  String = 15,
+  Number = 16,
+  Boolean = 17,
+  Array = 18,
+  Object = 19,
+  Key = 20,
+  Null = 21,
+  EnumMember = 22,
+  Struct = 23,
+  Event = 24,
+  Operator = 25,
+  TypeParameter = 26,
+}
+
+/**
+ * Human-readable names for symbol kinds
+ */
+export const SymbolKindNames: Record<SymbolKind, string> = {
+  [SymbolKind.File]: 'File',
+  [SymbolKind.Module]: 'Module',
+  [SymbolKind.Namespace]: 'Namespace',
+  [SymbolKind.Package]: 'Package',
+  [SymbolKind.Class]: 'Class',
+  [SymbolKind.Method]: 'Method',
+  [SymbolKind.Property]: 'Property',
+  [SymbolKind.Field]: 'Field',
+  [SymbolKind.Constructor]: 'Constructor',
+  [SymbolKind.Enum]: 'Enum',
+  [SymbolKind.Interface]: 'Interface',
+  [SymbolKind.Function]: 'Function',
+  [SymbolKind.Variable]: 'Variable',
+  [SymbolKind.Constant]: 'Constant',
+  [SymbolKind.String]: 'String',
+  [SymbolKind.Number]: 'Number',
+  [SymbolKind.Boolean]: 'Boolean',
+  [SymbolKind.Array]: 'Array',
+  [SymbolKind.Object]: 'Object',
+  [SymbolKind.Key]: 'Key',
+  [SymbolKind.Null]: 'Null',
+  [SymbolKind.EnumMember]: 'EnumMember',
+  [SymbolKind.Struct]: 'Struct',
+  [SymbolKind.Event]: 'Event',
+  [SymbolKind.Operator]: 'Operator',
+  [SymbolKind.TypeParameter]: 'TypeParameter',
+};
+
+/**
+ * Location information for a symbol in a source file.
+ */
+export interface SymbolLocation {
+  /** Relative path to the source file from the project root */
+  filepath: string;
+  /** Starting line number (1-indexed) */
+  startLine: number;
+  /** Ending line number (1-indexed) */
+  endLine: number;
+  /** Starting column (0-indexed) */
+  startColumn: number;
+  /** Ending column (0-indexed) */
+  endColumn: number;
+}
+
+/**
+ * A code symbol extracted from source code.
+ * Represents functions, classes, methods, variables, etc.
+ */
+export interface Symbol {
+  /** The symbol's name (e.g., 'MyClass', 'myMethod') */
+  name: string;
+  /**
+   * Hierarchical name path within the file.
+   * Format: "ClassName/methodName" or "/topLevelFunction"
+   * Uses "/" as separator to match Serena's convention.
+   */
+  namePath: string;
+  /** LSP-compatible symbol kind */
+  kind: SymbolKind;
+  /** Location in the source file */
+  location: SymbolLocation;
+  /** Parent symbol's name path, if this symbol is nested */
+  parentNamePath?: string;
+  /** Depth in the symbol hierarchy (0 = top-level) */
+  depth: number;
+  /** Child symbols (e.g., methods of a class) */
+  children?: Symbol[];
+  /** The symbol's source code body (only included when requested) */
+  body?: string;
+  /** Documentation/hover information (docstring, type signature) */
+  info?: string;
+}
+
+/**
+ * Result from find_symbol operations.
+ * Includes the matched symbols and their location info.
+ */
+export interface FindSymbolResult {
+  /** Matched symbols */
+  symbols: Symbol[];
+  /** Total number of matches found */
+  totalMatches: number;
+}
+
+/**
+ * Overview of symbols in a file, grouped by kind.
+ */
+export interface SymbolsOverview {
+  /** Relative path to the file */
+  filepath: string;
+  /** Symbols grouped by kind */
+  byKind: Record<string, SymbolOverviewEntry[]>;
+  /** Total number of symbols */
+  totalSymbols: number;
+}
+
+/**
+ * Compact symbol entry for overview (without body)
+ */
+export interface SymbolOverviewEntry {
+  /** Symbol name */
+  name: string;
+  /** Name path (hierarchical) */
+  namePath: string;
+  /** Line range */
+  lines: string;
+  /** Child count (if any) */
+  children?: number;
+}
+
+/**
+ * Options for the find_symbol tool.
+ */
+export interface FindSymbolOptions {
+  /** Name path pattern to search for */
+  namePathPattern: string;
+  /** Restrict search to this file or directory */
+  relativePath?: string;
+  /** Depth of descendants to retrieve (0 = symbol only) */
+  depth?: number;
+  /** Whether to include the symbol's source code body */
+  includeBody?: boolean;
+  /** Whether to include additional info (docstring, signature) */
+  includeInfo?: boolean;
+  /** Use substring matching for the last element of the pattern */
+  substringMatching?: boolean;
+  /** Symbol kinds to include (LSP kind integers) */
+  includeKinds?: SymbolKind[];
+  /** Symbol kinds to exclude (takes precedence over includeKinds) */
+  excludeKinds?: SymbolKind[];
+  /** Maximum response size in characters */
+  maxAnswerChars?: number;
+}
+
+/**
+ * Options for the get_symbols_overview tool.
+ */
+export interface SymbolsOverviewOptions {
+  /** Relative path to the file */
+  relativePath: string;
+  /** Depth of descendants to retrieve (0 = top-level only) */
+  depth?: number;
+  /** Maximum response size in characters */
+  maxAnswerChars?: number;
+}
+
+/**
+ * Reference to a symbol from another location in code.
+ */
+export interface SymbolReference {
+  /** The symbol containing the reference */
+  referencingSymbol: Symbol;
+  /** Code snippet around the reference */
+  codeSnippet: string;
+  /** Line number where the reference occurs */
+  line: number;
+  /** Column where the reference starts */
+  column: number;
+}
+
+/**
+ * Options for find_referencing_symbols tool.
+ */
+export interface FindReferencesOptions {
+  /** Name path of the symbol to find references for */
+  namePath: string;
+  /** Relative path to the file containing the symbol */
+  relativePath: string;
+  /** Whether to include additional info about referencing symbols */
+  includeInfo?: boolean;
+  /** Symbol kinds to include */
+  includeKinds?: SymbolKind[];
+  /** Symbol kinds to exclude */
+  excludeKinds?: SymbolKind[];
+  /** Maximum response size in characters */
+  maxAnswerChars?: number;
+}
+
+/**
+ * Options for search_for_pattern tool.
+ */
+export interface SearchPatternOptions {
+  /** Regular expression pattern to search for */
+  substringPattern: string;
+  /** Restrict search to this path (file or directory) */
+  relativePath?: string;
+  /** Only search in code files (not config, docs, etc.) */
+  restrictSearchToCodeFiles?: boolean;
+  /** Glob pattern for files to include */
+  pathsIncludeGlob?: string;
+  /** Glob pattern for files to exclude */
+  pathsExcludeGlob?: string;
+  /** Number of context lines before each match */
+  contextLinesBefore?: number;
+  /** Number of context lines after each match */
+  contextLinesAfter?: number;
+  /** Maximum response size in characters */
+  maxAnswerChars?: number;
+}
+
+/**
+ * Result from pattern search.
+ */
+export interface PatternSearchResult {
+  /** Map of filepath to matched lines with context */
+  matches: Record<string, PatternMatch[]>;
+  /** Total number of matches */
+  totalMatches: number;
+}
+
+/**
+ * A single pattern match with context.
+ */
+export interface PatternMatch {
+  /** Line number of the match (1-indexed) */
+  line: number;
+  /** The matched line and context */
+  content: string;
+  /** Column where match starts (0-indexed) */
+  matchStart?: number;
+  /** Length of the match */
+  matchLength?: number;
+}
+
+/**
+ * Map from AST chunk types to LSP symbol kinds.
+ */
+export function chunkTypeToSymbolKind(
+  chunkType:
+    | 'function'
+    | 'class'
+    | 'method'
+    | 'interface'
+    | 'type'
+    | 'variable'
+    | 'import'
+    | 'other'
+): SymbolKind {
+  switch (chunkType) {
+    case 'function':
+      return SymbolKind.Function;
+    case 'class':
+      return SymbolKind.Class;
+    case 'method':
+      return SymbolKind.Method;
+    case 'interface':
+      return SymbolKind.Interface;
+    case 'type':
+      return SymbolKind.TypeParameter;
+    case 'variable':
+      return SymbolKind.Variable;
+    case 'import':
+      return SymbolKind.Module;
+    case 'other':
+    default:
+      return SymbolKind.Variable;
+  }
+}
+
+/**
+ * Get symbol kind from a name (for parsing user input).
+ */
+export function parseSymbolKind(name: string): SymbolKind | undefined {
+  const normalized = name.toLowerCase();
+  for (const [kind, kindName] of Object.entries(SymbolKindNames)) {
+    if (kindName.toLowerCase() === normalized) {
+      return Number(kind) as SymbolKind;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Add comprehensive symbolic code analysis capabilities to the lance-context MCP server, providing Serena-like functionality using Tree-sitter and TypeScript compiler.

### New Tools (13 total)

**Symbol Navigation:**
- `get_symbols_overview` - List symbols grouped by kind (Class, Function, etc.)
- `find_symbol` - Search by name path pattern (e.g., "MyClass/myMethod", "get*")
- `find_referencing_symbols` - Find all references to a symbol
- `search_for_pattern` - Regex search with context lines

**Symbol Editing:**
- `replace_symbol_body` - Replace entire symbol definition
- `insert_before_symbol` - Add code before a symbol
- `insert_after_symbol` - Add code after a symbol
- `rename_symbol` - Rename symbol across codebase

**Memory System:**
- `write_memory` - Save project-specific notes/decisions
- `read_memory` - Retrieve saved context
- `list_memories` - List available memories
- `edit_memory` - Find/replace in memory
- `delete_memory` - Remove a memory

### Language Support

- TypeScript/JavaScript (via TS compiler)
- Python, Go, Rust, Java, Ruby (via Tree-sitter)

### Key Features

- Hierarchical name paths (e.g., `MyClass/myMethod`)
- Pattern matching with glob support (`get*`)
- Atomic file writes for safe editing
- Indentation preservation
- Dry-run mode for rename preview

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (568 tests)
- [x] ESLint/Prettier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)