### PR TITLE
Add generated files and symlinks to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,19 @@ Thumbs.db
 *.log
 npm-debug.log*
 coverage/
+
+# Claude Code auto-generated context
+**/CLAUDE.md
+.claude/plugins/
+
+# Serena MCP
+.serena/
+
+# Beads (keep issues.jsonl tracked)
+.beads/*
+!.beads/issues.jsonl
+
+# Symlinked directories
+gt/
+lancecontext/
+mayor/


### PR DESCRIPTION
## Summary
- Ignore `CLAUDE.md` auto-generated context files
- Ignore `.claude/plugins/` directory
- Ignore `.serena/` MCP files
- Ignore `.beads/*` except `issues.jsonl` (tracked for sync)
- Ignore symlinked directories (`gt/`, `lancecontext/`, `mayor/`)