### PR TITLE
feat(index): add corruption detection and auto-repair

### DIFF
--- a/src/__tests__/mocks/lancedb.mock.ts
+++ b/src/__tests__/mocks/lancedb.mock.ts
@@ -1,13 +1,14 @@
 import { vi } from 'vitest';
 
 export interface MockRow {
-  id: string;
+  id?: string;
   filepath: string;
-  content: string;
-  startLine: number;
-  endLine: number;
-  language: string;
+  content?: string;
+  startLine?: number;
+  endLine?: number;
+  language?: string;
   vector?: number[];
+  mtime?: number;
   symbolType?:
     | 'function'
     | 'class'


### PR DESCRIPTION
## Summary

- Add SHA256-based checksum validation for index integrity verification
- Detect missing metadata, chunk count mismatch, and file list inconsistencies
- Add `autoRepair` parameter to `index_codebase` that automatically rebuilds corrupted indexes
- Display clear corruption warnings and recovery instructions in `get_index_status`

## Test plan

- [x] Run `npm test` - all 572 tests pass
- [ ] Manually test with corrupted index (delete metadata file, verify detection)
- [ ] Test autoRepair parameter triggers rebuild on corruption
- [ ] Verify get_index_status shows corruption warnings

Generated with [Claude Code](https://claude.com/claude-code)