### PR TITLE
Add git worktree tools for parallel agent isolation

### DIFF
--- a/src/__tests__/worktree/worktree-manager.test.ts
+++ b/src/__tests__/worktree/worktree-manager.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import { exec } from 'child_process';
+import {
+  WorktreeManager,
+  formatWorktreeInfo,
+  formatWorktreeList,
+} from '../../worktree/worktree-manager.js';
+import type { WorktreeInfo, ListWorktreesResult } from '../../worktree/types.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Mock fs
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+describe('WorktreeManager', () => {
+  const projectPath = '/test/project';
+  let manager: WorktreeManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorktreeManager(projectPath);
+  });
+
+  describe('createWorktree', () => {
+    it('should create a worktree with correct naming', async () => {
+      const mockExec = vi.mocked(exec);
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      const mockStatSync = vi.mocked(fs.statSync);
+
+      // Track what paths have been "created"
+      let worktreeCreated = false;
+
+      // Setup mocks
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const pathStr = String(p);
+        // Worktree dir - exists only after creation
+        if (pathStr.includes('agent-worktrees/add-auth')) {
+          return worktreeCreated;
+        }
+        // agent-worktrees dir doesn't exist initially
+        if (pathStr.endsWith('agent-worktrees')) return false;
+        return false;
+      });
+
+      mockStatSync.mockReturnValue({
+        birthtime: new Date(),
+      } as fs.Stats);
+
+      // Mock git commands
+      mockExec.mockImplementation((cmd: string, opts: any, callback?: any) => {
+        const cb = typeof opts === 'function' ? opts : callback;
+        const cmdStr = String(cmd);
+
+        if (cmdStr.includes('rev-parse --verify feature/add-auth')) {
+          // Branch doesn't exist
+          cb(new Error('not found'), '', '');
+        } else if (cmdStr.includes('rev-parse --verify main')) {
+          cb(null, { stdout: 'abc123\n', stderr: '' });
+        } else if (cmdStr.includes('worktree add')) {
+          // Mark worktree as created
+          worktreeCreated = true;
+          cb(null, { stdout: 'Preparing worktree\n', stderr: '' });
+        } else if (cmdStr.includes('branch --show-current')) {
+          cb(null, { stdout: 'feature/add-auth\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --short HEAD')) {
+          cb(null, { stdout: 'abc1234\n', stderr: '' });
+        } else if (cmdStr.includes('status --porcelain')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('rev-list --left-right')) {
+          cb(null, { stdout: '0\t1\n', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+        return {} as any;
+      });
+
+      const result = await manager.createWorktree({
+        shortName: 'add-auth',
+        installDeps: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.worktree).toBeDefined();
+      expect(result.worktree?.branch).toBe('feature/add-auth');
+    });
+
+    it('should fail on duplicate worktree', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockReturnValue(true);
+
+      const result = await manager.createWorktree({
+        shortName: 'existing',
+        installDeps: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already exists');
+    });
+
+    it('should include issue ID in naming', async () => {
+      const mockExec = vi.mocked(exec);
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        const pathStr = String(p);
+        if (pathStr.includes('bd-123-add-auth')) return false;
+        return pathStr.includes('.git');
+      });
+
+      let capturedCmd = '';
+      mockExec.mockImplementation((cmd: string, opts: any, callback?: any) => {
+        const cb = typeof opts === 'function' ? opts : callback;
+        const cmdStr = String(cmd);
+
+        if (cmdStr.includes('worktree add')) {
+          capturedCmd = cmdStr;
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --verify feature/bd-123-add-auth')) {
+          cb(new Error('not found'), '', '');
+        } else if (cmdStr.includes('rev-parse --verify main')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('branch --show-current')) {
+          cb(null, { stdout: 'feature/bd-123-add-auth\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --short HEAD')) {
+          cb(null, { stdout: 'abc1234\n', stderr: '' });
+        } else if (cmdStr.includes('status --porcelain')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('rev-list --left-right')) {
+          cb(null, { stdout: '0\t0\n', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+        return {} as any;
+      });
+
+      await manager.createWorktree({
+        shortName: 'add-auth',
+        issueId: 'bd-123',
+        installDeps: false,
+      });
+
+      expect(capturedCmd).toContain('feature/bd-123-add-auth');
+      expect(capturedCmd).toContain('bd-123-add-auth');
+    });
+  });
+
+  describe('listWorktrees', () => {
+    it('should return empty list when no worktrees', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await manager.listWorktrees();
+
+      expect(result.worktrees).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it('should list populated worktrees', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      const mockReaddirSync = vi.mocked(fs.readdirSync);
+      const mockExec = vi.mocked(exec);
+
+      mockExistsSync.mockReturnValue(true);
+      (mockReaddirSync as any).mockReturnValue([
+        { name: 'worktree-1', isDirectory: () => true },
+        { name: 'worktree-2', isDirectory: () => true },
+      ]);
+
+      mockExec.mockImplementation((cmd: string, opts: any, callback?: any) => {
+        const cb = typeof opts === 'function' ? opts : callback;
+        const cmdStr = String(cmd);
+
+        if (cmdStr.includes('branch --show-current')) {
+          cb(null, { stdout: 'feature/test\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --short HEAD')) {
+          cb(null, { stdout: 'abc1234\n', stderr: '' });
+        } else if (cmdStr.includes('status --porcelain')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('rev-list --left-right')) {
+          cb(null, { stdout: '0\t0\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --verify main')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+        return {} as any;
+      });
+
+      const result = await manager.listWorktrees();
+
+      expect(result.count).toBe(2);
+      expect(result.worktrees.length).toBe(2);
+    });
+  });
+
+  describe('removeWorktree', () => {
+    it('should fail on non-existent worktree', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await manager.removeWorktree({ name: 'nonexistent' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('does not exist');
+    });
+
+    it('should fail on dirty worktree without force', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      const mockExec = vi.mocked(exec);
+
+      mockExistsSync.mockReturnValue(true);
+
+      mockExec.mockImplementation((cmd: string, opts: any, callback?: any) => {
+        const cb = typeof opts === 'function' ? opts : callback;
+        const cmdStr = String(cmd);
+
+        if (cmdStr.includes('branch --show-current')) {
+          cb(null, { stdout: 'feature/test\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --short HEAD')) {
+          cb(null, { stdout: 'abc1234\n', stderr: '' });
+        } else if (cmdStr.includes('status --porcelain')) {
+          // Return dirty status
+          cb(null, { stdout: 'M file.ts\n', stderr: '' });
+        } else if (cmdStr.includes('rev-list --left-right')) {
+          cb(null, { stdout: '0\t0\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --verify main')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+        return {} as any;
+      });
+
+      const result = await manager.removeWorktree({ name: 'dirty-worktree' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('uncommitted changes');
+    });
+
+    it('should remove worktree and branch when requested', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      const mockExec = vi.mocked(exec);
+
+      mockExistsSync.mockReturnValue(true);
+
+      const executedCommands: string[] = [];
+      mockExec.mockImplementation((cmd: string, opts: any, callback?: any) => {
+        const cb = typeof opts === 'function' ? opts : callback;
+        const cmdStr = String(cmd);
+        executedCommands.push(cmdStr);
+
+        if (cmdStr.includes('branch --show-current')) {
+          cb(null, { stdout: 'feature/test\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --short HEAD')) {
+          cb(null, { stdout: 'abc1234\n', stderr: '' });
+        } else if (cmdStr.includes('status --porcelain')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('rev-list --left-right')) {
+          cb(null, { stdout: '0\t0\n', stderr: '' });
+        } else if (cmdStr.includes('rev-parse --verify main')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('worktree remove')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmdStr.includes('branch -D')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+        return {} as any;
+      });
+
+      const result = await manager.removeWorktree({
+        name: 'test-worktree',
+        deleteBranch: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.branchDeleted).toBe(true);
+      expect(executedCommands.some((cmd) => cmd.includes('worktree remove'))).toBe(true);
+      expect(executedCommands.some((cmd) => cmd.includes('branch -D'))).toBe(true);
+    });
+  });
+
+  describe('detectPackageManager', () => {
+    it('should detect bun from bun.lockb', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        return String(p).endsWith('bun.lockb');
+      });
+
+      const result = await manager.detectPackageManager('/test/dir');
+      expect(result).toBe('bun');
+    });
+
+    it('should detect pnpm from pnpm-lock.yaml', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        return String(p).endsWith('pnpm-lock.yaml');
+      });
+
+      const result = await manager.detectPackageManager('/test/dir');
+      expect(result).toBe('pnpm');
+    });
+
+    it('should detect yarn from yarn.lock', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        return String(p).endsWith('yarn.lock');
+      });
+
+      const result = await manager.detectPackageManager('/test/dir');
+      expect(result).toBe('yarn');
+    });
+
+    it('should detect npm from package-lock.json', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+
+      mockExistsSync.mockImplementation((p: fs.PathLike) => {
+        return String(p).endsWith('package-lock.json');
+      });
+
+      const result = await manager.detectPackageManager('/test/dir');
+      expect(result).toBe('npm');
+    });
+
+    it('should return null when no package.json', async () => {
+      const mockExistsSync = vi.mocked(fs.existsSync);
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await manager.detectPackageManager('/test/dir');
+      expect(result).toBe(null);
+    });
+  });
+});
+
+describe('formatWorktreeInfo', () => {
+  it('should format worktree info correctly', () => {
+    const info: WorktreeInfo = {
+      name: 'test-worktree',
+      path: '/project/.git/agent-worktrees/test-worktree',
+      branch: 'feature/test',
+      commit: 'abc1234',
+      valid: true,
+      dirty: false,
+      ahead: 2,
+      behind: 1,
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+    };
+
+    const formatted = formatWorktreeInfo(info);
+
+    expect(formatted).toContain('## Worktree: test-worktree');
+    expect(formatted).toContain('**Branch:** feature/test');
+    expect(formatted).toContain('**Commit:** abc1234');
+    expect(formatted).toContain('**Status:** clean');
+    expect(formatted).toContain('**Ahead/Behind:** +2/-1');
+  });
+
+  it('should show dirty status', () => {
+    const info: WorktreeInfo = {
+      name: 'dirty-worktree',
+      path: '/project/.git/agent-worktrees/dirty-worktree',
+      branch: 'feature/dirty',
+      commit: 'def5678',
+      valid: true,
+      dirty: true,
+      ahead: 0,
+      behind: 0,
+    };
+
+    const formatted = formatWorktreeInfo(info);
+
+    expect(formatted).toContain('**Status:** dirty');
+  });
+
+  it('should show invalid status', () => {
+    const info: WorktreeInfo = {
+      name: 'invalid-worktree',
+      path: '/project/.git/agent-worktrees/invalid-worktree',
+      branch: '',
+      commit: '',
+      valid: false,
+      dirty: false,
+      ahead: 0,
+      behind: 0,
+    };
+
+    const formatted = formatWorktreeInfo(info);
+
+    expect(formatted).toContain('**Status:** invalid');
+  });
+});
+
+describe('formatWorktreeList', () => {
+  it('should show message for empty list', () => {
+    const result: ListWorktreesResult = { worktrees: [], count: 0 };
+    const formatted = formatWorktreeList(result);
+
+    expect(formatted).toBe('No agent worktrees found.');
+  });
+
+  it('should format list of worktrees', () => {
+    const result: ListWorktreesResult = {
+      worktrees: [
+        {
+          name: 'wt-1',
+          path: '/project/.git/agent-worktrees/wt-1',
+          branch: 'feature/test-1',
+          commit: 'abc1234',
+          valid: true,
+          dirty: false,
+          ahead: 1,
+          behind: 0,
+        },
+        {
+          name: 'wt-2',
+          path: '/project/.git/agent-worktrees/wt-2',
+          branch: 'fix/bug',
+          commit: 'def5678',
+          valid: true,
+          dirty: true,
+          ahead: 0,
+          behind: 2,
+        },
+      ],
+      count: 2,
+    };
+
+    const formatted = formatWorktreeList(result);
+
+    expect(formatted).toContain('Found 2 worktree(s)');
+    expect(formatted).toContain('**wt-1** on `feature/test-1` (clean) [+1/-0]');
+    expect(formatted).toContain('**wt-2** on `fix/bug` (dirty) [+0/-2]');
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -14,6 +14,7 @@ export type ErrorCategory =
   | 'embedding' // Embedding generation failures
   | 'config' // Configuration errors
   | 'git' // Git operation failures
+  | 'worktree' // Git worktree operation failures
   | 'internal'; // Unexpected internal errors
 
 /**

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Git worktree management module for parallel agent isolation.
+ */
+
+// Types
+export type {
+  BranchPrefix,
+  PackageManager,
+  WorktreeInfo,
+  CreateWorktreeOptions,
+  CreateWorktreeResult,
+  RemoveWorktreeOptions,
+  RemoveWorktreeResult,
+  ListWorktreesResult,
+} from './types.js';
+
+// Manager
+export { WorktreeManager, formatWorktreeInfo, formatWorktreeList } from './worktree-manager.js';

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Types and interfaces for git worktree management.
+ * Enables parallel agent isolation through automatic worktree creation.
+ */
+
+/**
+ * Branch prefix types that follow .claude/rules.md conventions.
+ */
+export type BranchPrefix = 'feature' | 'fix' | 'refactor' | 'docs' | 'test';
+
+/**
+ * Package manager types for dependency installation.
+ */
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+
+/**
+ * Information about a git worktree.
+ */
+export interface WorktreeInfo {
+  /** Worktree name (directory name within .git/agent-worktrees/) */
+  name: string;
+  /** Full path to the worktree directory */
+  path: string;
+  /** Branch name the worktree is on */
+  branch: string;
+  /** Current HEAD commit hash (short) */
+  commit: string;
+  /** Whether the worktree is valid/exists */
+  valid: boolean;
+  /** Whether there are uncommitted changes */
+  dirty: boolean;
+  /** Number of commits ahead of base branch */
+  ahead: number;
+  /** Number of commits behind base branch */
+  behind: number;
+  /** Timestamp when the worktree was created */
+  createdAt?: Date;
+}
+
+/**
+ * Options for creating a new worktree.
+ */
+export interface CreateWorktreeOptions {
+  /** Issue ID (e.g., "bd-123") - optional, used for naming */
+  issueId?: string;
+  /** Short descriptive name (e.g., "add-auth") - required */
+  shortName: string;
+  /** Branch prefix (default: "feature") */
+  prefix?: BranchPrefix;
+  /** Base branch to create from (default: current branch or main) */
+  baseBranch?: string;
+  /** Whether to install dependencies after creation (default: true) */
+  installDeps?: boolean;
+  /** Package manager to use (default: auto-detect) */
+  packageManager?: PackageManager;
+}
+
+/**
+ * Result from creating a worktree.
+ */
+export interface CreateWorktreeResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Worktree info if successful */
+  worktree?: WorktreeInfo;
+  /** Error message if failed */
+  error?: string;
+  /** Whether dependencies were installed */
+  depsInstalled?: boolean;
+  /** Time taken to install dependencies (ms) */
+  depsInstallTime?: number;
+}
+
+/**
+ * Options for removing a worktree.
+ */
+export interface RemoveWorktreeOptions {
+  /** Worktree name to remove */
+  name: string;
+  /** Whether to also delete the branch (default: false) */
+  deleteBranch?: boolean;
+  /** Force removal even if dirty (default: false) */
+  force?: boolean;
+}
+
+/**
+ * Result from removing a worktree.
+ */
+export interface RemoveWorktreeResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Branch name that was associated */
+  branch?: string;
+  /** Whether the branch was deleted */
+  branchDeleted?: boolean;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Result from listing worktrees.
+ */
+export interface ListWorktreesResult {
+  /** List of worktrees */
+  worktrees: WorktreeInfo[];
+  /** Total count */
+  count: number;
+}

--- a/src/worktree/worktree-manager.ts
+++ b/src/worktree/worktree-manager.ts
@@ -1,0 +1,468 @@
+/**
+ * Git worktree management for parallel agent isolation.
+ *
+ * Creates isolated workspaces in .git/agent-worktrees/ to allow multiple
+ * agents to work simultaneously without file conflicts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import type {
+  PackageManager,
+  WorktreeInfo,
+  CreateWorktreeOptions,
+  CreateWorktreeResult,
+  RemoveWorktreeOptions,
+  RemoveWorktreeResult,
+  ListWorktreesResult,
+} from './types.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Manages git worktrees for parallel agent isolation.
+ */
+export class WorktreeManager {
+  private readonly projectPath: string;
+  private readonly worktreesDir: string;
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath;
+    this.worktreesDir = path.join(projectPath, '.git', 'agent-worktrees');
+  }
+
+  /**
+   * Ensure the worktrees directory exists.
+   */
+  private async ensureWorktreesDir(): Promise<void> {
+    if (!fs.existsSync(this.worktreesDir)) {
+      fs.mkdirSync(this.worktreesDir, { recursive: true });
+    }
+  }
+
+  /**
+   * Generate a worktree name from options.
+   */
+  private generateName(options: CreateWorktreeOptions): string {
+    if (options.issueId) {
+      return `${options.issueId}-${options.shortName}`;
+    }
+    return options.shortName;
+  }
+
+  /**
+   * Generate a branch name from options.
+   */
+  private generateBranchName(options: CreateWorktreeOptions): string {
+    const prefix = options.prefix || 'feature';
+    const name = this.generateName(options);
+    return `${prefix}/${name}`;
+  }
+
+  /**
+   * Detect the package manager used in a directory.
+   */
+  async detectPackageManager(dir: string): Promise<PackageManager | null> {
+    // Check for lock files in order of preference
+    const lockFiles: Array<{ file: string; manager: PackageManager }> = [
+      { file: 'bun.lockb', manager: 'bun' },
+      { file: 'pnpm-lock.yaml', manager: 'pnpm' },
+      { file: 'yarn.lock', manager: 'yarn' },
+      { file: 'package-lock.json', manager: 'npm' },
+    ];
+
+    for (const { file, manager } of lockFiles) {
+      if (fs.existsSync(path.join(dir, file))) {
+        return manager;
+      }
+    }
+
+    // Check if package.json exists at all
+    if (fs.existsSync(path.join(dir, 'package.json'))) {
+      return 'npm'; // Default to npm if package.json exists but no lock file
+    }
+
+    return null;
+  }
+
+  /**
+   * Install dependencies in a directory.
+   */
+  async installDependencies(
+    dir: string,
+    packageManager?: PackageManager
+  ): Promise<{ success: boolean; time: number; error?: string }> {
+    const startTime = Date.now();
+
+    const manager = packageManager || (await this.detectPackageManager(dir));
+    if (!manager) {
+      return { success: true, time: 0 }; // No package.json, nothing to install
+    }
+
+    const commands: Record<PackageManager, string> = {
+      npm: 'npm install',
+      yarn: 'yarn install',
+      pnpm: 'pnpm install',
+      bun: 'bun install',
+    };
+
+    try {
+      await execAsync(commands[manager], {
+        cwd: dir,
+        env: { ...process.env, CI: 'true' }, // Suppress interactive prompts
+      });
+      return { success: true, time: Date.now() - startTime };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, time: Date.now() - startTime, error: message };
+    }
+  }
+
+  /**
+   * Get the current branch name.
+   */
+  async getCurrentBranch(): Promise<string> {
+    try {
+      const { stdout } = await execAsync('git branch --show-current', { cwd: this.projectPath });
+      return stdout.trim() || 'main';
+    } catch {
+      return 'main';
+    }
+  }
+
+  /**
+   * Get the default base branch (main or master).
+   */
+  async getDefaultBaseBranch(): Promise<string> {
+    try {
+      // Check if main exists
+      await execAsync('git rev-parse --verify main', { cwd: this.projectPath });
+      return 'main';
+    } catch {
+      try {
+        // Check if master exists
+        await execAsync('git rev-parse --verify master', { cwd: this.projectPath });
+        return 'master';
+      } catch {
+        // Default to whatever the current branch is
+        return this.getCurrentBranch();
+      }
+    }
+  }
+
+  /**
+   * Check if a branch exists.
+   */
+  async branchExists(branchName: string): Promise<boolean> {
+    try {
+      await execAsync(`git rev-parse --verify ${branchName}`, { cwd: this.projectPath });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Create a new worktree for isolated agent work.
+   */
+  async createWorktree(options: CreateWorktreeOptions): Promise<CreateWorktreeResult> {
+    await this.ensureWorktreesDir();
+
+    const name = this.generateName(options);
+    const worktreePath = path.join(this.worktreesDir, name);
+    const branchName = this.generateBranchName(options);
+
+    // Check if worktree already exists
+    if (fs.existsSync(worktreePath)) {
+      return {
+        success: false,
+        error: `Worktree "${name}" already exists at ${worktreePath}`,
+      };
+    }
+
+    // Check if branch already exists
+    if (await this.branchExists(branchName)) {
+      return {
+        success: false,
+        error: `Branch "${branchName}" already exists. Use a different short_name or issue_id.`,
+      };
+    }
+
+    // Determine base branch
+    const baseBranch = options.baseBranch || (await this.getDefaultBaseBranch());
+
+    try {
+      // Create worktree with a new branch
+      await execAsync(`git worktree add -b ${branchName} "${worktreePath}" ${baseBranch}`, {
+        cwd: this.projectPath,
+      });
+
+      // Get worktree info
+      const info = await this.getWorktreeInfo(name);
+      if (!info) {
+        return {
+          success: false,
+          error: 'Worktree created but failed to get info',
+        };
+      }
+
+      // Install dependencies if requested (default: true)
+      let depsInstalled = false;
+      let depsInstallTime: number | undefined;
+
+      if (options.installDeps !== false) {
+        const installResult = await this.installDependencies(worktreePath, options.packageManager);
+        depsInstalled = installResult.success;
+        depsInstallTime = installResult.time;
+
+        if (!installResult.success) {
+          // Don't fail the worktree creation, just note the issue
+          console.error(`[worktree] Dependency installation failed: ${installResult.error}`);
+        }
+      }
+
+      return {
+        success: true,
+        worktree: info,
+        depsInstalled,
+        depsInstallTime,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Failed to create worktree: ${message}`,
+      };
+    }
+  }
+
+  /**
+   * Get information about a specific worktree.
+   */
+  async getWorktreeInfo(name: string): Promise<WorktreeInfo | null> {
+    const worktreePath = path.join(this.worktreesDir, name);
+
+    if (!fs.existsSync(worktreePath)) {
+      return null;
+    }
+
+    try {
+      // Get branch name
+      const { stdout: branchOutput } = await execAsync('git branch --show-current', {
+        cwd: worktreePath,
+      });
+      const branch = branchOutput.trim();
+
+      // Get current commit (short hash)
+      const { stdout: commitOutput } = await execAsync('git rev-parse --short HEAD', {
+        cwd: worktreePath,
+      });
+      const commit = commitOutput.trim();
+
+      // Check if dirty (uncommitted changes)
+      let dirty = false;
+      try {
+        const { stdout: statusOutput } = await execAsync('git status --porcelain', {
+          cwd: worktreePath,
+        });
+        dirty = statusOutput.trim().length > 0;
+      } catch {
+        dirty = false;
+      }
+
+      // Get ahead/behind count relative to origin
+      let ahead = 0;
+      let behind = 0;
+      try {
+        // Get the default base branch for comparison
+        const baseBranch = await this.getDefaultBaseBranch();
+        const { stdout: aheadBehindOutput } = await execAsync(
+          `git rev-list --left-right --count ${baseBranch}...HEAD`,
+          { cwd: worktreePath }
+        );
+        const [behindStr, aheadStr] = aheadBehindOutput.trim().split('\t');
+        behind = parseInt(behindStr, 10) || 0;
+        ahead = parseInt(aheadStr, 10) || 0;
+      } catch {
+        // Ignore errors - ahead/behind may not be available
+      }
+
+      // Get creation time from directory stat
+      let createdAt: Date | undefined;
+      try {
+        const stats = fs.statSync(worktreePath);
+        createdAt = stats.birthtime;
+      } catch {
+        // Ignore
+      }
+
+      return {
+        name,
+        path: worktreePath,
+        branch,
+        commit,
+        valid: true,
+        dirty,
+        ahead,
+        behind,
+        createdAt,
+      };
+    } catch {
+      // Worktree exists but git commands failed - may be in invalid state
+      return {
+        name,
+        path: worktreePath,
+        branch: '',
+        commit: '',
+        valid: false,
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+      };
+    }
+  }
+
+  /**
+   * List all agent worktrees.
+   */
+  async listWorktrees(): Promise<ListWorktreesResult> {
+    if (!fs.existsSync(this.worktreesDir)) {
+      return { worktrees: [], count: 0 };
+    }
+
+    const entries = fs.readdirSync(this.worktreesDir, { withFileTypes: true });
+    const worktrees: WorktreeInfo[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const info = await this.getWorktreeInfo(entry.name);
+        if (info) {
+          worktrees.push(info);
+        }
+      }
+    }
+
+    // Sort by creation time (newest first)
+    worktrees.sort((a, b) => {
+      if (a.createdAt && b.createdAt) {
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    return { worktrees, count: worktrees.length };
+  }
+
+  /**
+   * Remove a worktree.
+   */
+  async removeWorktree(options: RemoveWorktreeOptions): Promise<RemoveWorktreeResult> {
+    const worktreePath = path.join(this.worktreesDir, options.name);
+
+    if (!fs.existsSync(worktreePath)) {
+      return {
+        success: false,
+        error: `Worktree "${options.name}" does not exist`,
+      };
+    }
+
+    // Get info before removal to know the branch name
+    const info = await this.getWorktreeInfo(options.name);
+    const branchName = info?.branch;
+
+    // Check if dirty and force not specified
+    if (info?.dirty && !options.force) {
+      return {
+        success: false,
+        branch: branchName,
+        error: `Worktree "${options.name}" has uncommitted changes. Use force=true to remove anyway.`,
+      };
+    }
+
+    try {
+      // Remove the worktree
+      const forceFlag = options.force ? '--force' : '';
+      await execAsync(`git worktree remove ${forceFlag} "${worktreePath}"`, {
+        cwd: this.projectPath,
+      });
+
+      // Optionally delete the branch
+      let branchDeleted = false;
+      if (options.deleteBranch && branchName) {
+        try {
+          await execAsync(`git branch -D ${branchName}`, { cwd: this.projectPath });
+          branchDeleted = true;
+        } catch (error) {
+          // Branch deletion failed - not critical
+          console.error(`[worktree] Failed to delete branch ${branchName}:`, error);
+        }
+      }
+
+      return {
+        success: true,
+        branch: branchName,
+        branchDeleted,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        branch: branchName,
+        error: `Failed to remove worktree: ${message}`,
+      };
+    }
+  }
+
+  /**
+   * Prune stale worktree entries from git.
+   */
+  async pruneWorktrees(): Promise<void> {
+    await execAsync('git worktree prune', { cwd: this.projectPath });
+  }
+}
+
+/**
+ * Format worktree info for display.
+ */
+export function formatWorktreeInfo(info: WorktreeInfo): string {
+  const parts: string[] = [];
+
+  parts.push(`## Worktree: ${info.name}`);
+  parts.push(`**Path:** ${info.path}`);
+  parts.push(`**Branch:** ${info.branch}`);
+  parts.push(`**Commit:** ${info.commit}`);
+  parts.push(`**Status:** ${info.valid ? (info.dirty ? 'dirty' : 'clean') : 'invalid'}`);
+
+  if (info.ahead > 0 || info.behind > 0) {
+    parts.push(`**Ahead/Behind:** +${info.ahead}/-${info.behind}`);
+  }
+
+  if (info.createdAt) {
+    parts.push(`**Created:** ${info.createdAt.toISOString()}`);
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Format list of worktrees for display.
+ */
+export function formatWorktreeList(result: ListWorktreesResult): string {
+  if (result.count === 0) {
+    return 'No agent worktrees found.';
+  }
+
+  const parts: string[] = [];
+  parts.push(`Found ${result.count} worktree(s):\n`);
+
+  for (const wt of result.worktrees) {
+    const status = wt.valid ? (wt.dirty ? '(dirty)' : '(clean)') : '(invalid)';
+    const aheadBehind = wt.ahead > 0 || wt.behind > 0 ? ` [+${wt.ahead}/-${wt.behind}]` : '';
+    parts.push(`- **${wt.name}** on \`${wt.branch}\` ${status}${aheadBehind}`);
+    parts.push(`  Path: ${wt.path}`);
+  }
+
+  return parts.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools for git worktree management: `create_worktree`, `list_worktrees`, `remove_worktree`, `worktree_status`
- Enables parallel agents to work in isolated workspaces without file conflicts
- Auto-detects package manager and optionally installs dependencies in new worktrees

## Test plan
- [x] All 604 tests pass including 18 new worktree tests
- [ ] Manual test: create worktree, verify directory and branch created
- [ ] Manual test: list worktrees shows status correctly
- [ ] Manual test: remove worktree cleans up directory and optionally branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)