### PR TITLE
fix(hooks): allow CI commits to main for semantic-release

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Allow commits in CI environment (for semantic-release)
+if [ "$CI" = "true" ]; then
+  exit 0
+fi
+
 # Block direct commits to main branch
 current_branch=$(git branch --show-current)
 if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then


### PR DESCRIPTION
## Summary
The pre-commit hook was blocking semantic-release from committing version bumps to main.

Fix: Skip the main branch check when `CI=true` environment variable is set (GitHub Actions sets this).

## Test plan
- [x] Pre-commit hook still blocks local commits to main
- [ ] semantic-release can commit to main in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)