### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Only run one release at a time
 concurrency:


### PR DESCRIPTION
Allow manual triggering of release workflow to retry failed publishes.