### PR TITLE
feat(dashboard): display package version in header

### DIFF
--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -18,6 +18,8 @@ export interface DashboardOptions {
   config?: LanceContextConfig;
   /** The project path */
   projectPath?: string;
+  /** Package version to display */
+  version?: string;
 }
 
 /**
@@ -47,6 +49,9 @@ export class DashboardManager {
     }
     if (options.projectPath) {
       dashboardState.setProjectPath(options.projectPath);
+    }
+    if (options.version) {
+      dashboardState.setVersion(options.version);
     }
 
     this.serverInstance = await startServer(options.port);

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -55,6 +55,7 @@ async function handleStatus(_req: IncomingMessage, res: ServerResponse): Promise
     sendJSON(res, {
       ...status,
       isIndexing: dashboardState.isIndexingInProgress(),
+      version: dashboardState.getVersion(),
     });
   } catch (error) {
     sendJSON(res, { error: String(error) }, 500);

--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -105,6 +105,7 @@ export class DashboardStateManager extends EventEmitter {
   private indexer: CodeIndexer | null = null;
   private config: LanceContextConfig | null = null;
   private projectPath: string | null = null;
+  private version: string | null = null;
   private isIndexing = false;
   private lastProgress: IndexProgress | null = null;
   private commandUsage: Map<CommandName, number> = new Map();
@@ -177,6 +178,20 @@ export class DashboardStateManager extends EventEmitter {
   setProjectPath(projectPath: string): void {
     this.projectPath = projectPath;
     this.loadUsageFromDisk();
+  }
+
+  /**
+   * Set the package version
+   */
+  setVersion(version: string): void {
+    this.version = version;
+  }
+
+  /**
+   * Get the package version
+   */
+  getVersion(): string | null {
+    return this.version;
   }
 
   /**

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -164,6 +164,13 @@ export function getDashboardHTML(): string {
       height: 40px;
     }
 
+    .version-badge {
+      font-size: 12px;
+      font-weight: 400;
+      color: var(--text-muted);
+      margin-left: 4px;
+    }
+
     .theme-toggle {
       display: flex;
       align-items: center;
@@ -746,6 +753,7 @@ export function getDashboardHTML(): string {
         <h1>
           <div class="logo">${LOGO_SVG}</div>
           lance-context
+          <span class="version-badge" id="versionBadge"></span>
         </h1>
       </div>
       <div class="header-right">
@@ -978,6 +986,7 @@ export function getDashboardHTML(): string {
     // DOM elements
     const connectionDot = document.getElementById('connectionDot');
     const connectionText = document.getElementById('connectionText');
+    const versionBadge = document.getElementById('versionBadge');
     const indexBadge = document.getElementById('indexBadge');
     const fileCount = document.getElementById('fileCount');
     const chunkCount = document.getElementById('chunkCount');
@@ -1116,6 +1125,11 @@ export function getDashboardHTML(): string {
       lastUpdated.textContent = formatDate(status.lastUpdated);
       embeddingBackend.textContent = status.embeddingBackend || 'Not configured';
       indexPath.textContent = status.indexPath || '-';
+
+      // Update version badge
+      if (status.version) {
+        versionBadge.textContent = 'v' + status.version;
+      }
     }
 
     // Update config display

--- a/src/index.ts
+++ b/src/index.ts
@@ -2232,6 +2232,7 @@ async function main() {
           port: dashboardPort,
           config,
           projectPath: PROJECT_PATH,
+          version: PACKAGE_VERSION,
         });
         console.error(`[lance-context] Dashboard started at ${dashboard.url}`);
 


### PR DESCRIPTION
## Summary

- Add version display to the dashboard header (shows as "v1.0.1" next to "lance-context")
- Version flows through dashboard state management system
- Version is included in `/api/status` response

## Changes

- `src/dashboard/state.ts`: Add version field with getter/setter methods
- `src/dashboard/index.ts`: Add version option to DashboardOptions interface
- `src/dashboard/routes.ts`: Include version in status API response
- `src/dashboard/ui.ts`: Display version badge in header with subtle styling
- `src/index.ts`: Pass PACKAGE_VERSION when starting dashboard

## Test plan

- [ ] Start dashboard server, verify version shows in header as "vX.X.X"
- [ ] Run `/mcp` in Claude Code, confirm version is visible in MCP info
- [ ] Run `npm test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)