### PR TITLE
feat: add reusable TTLCache utility class

### DIFF
--- a/src/__tests__/utils/cache.test.ts
+++ b/src/__tests__/utils/cache.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TTLCache } from '../../utils/cache.js';
+
+describe('TTLCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('basic operations', () => {
+    it('should store and retrieve values', () => {
+      const cache = new TTLCache<string>();
+      cache.set('key1', 'value1');
+      expect(cache.get('key1')).toBe('value1');
+    });
+
+    it('should return undefined for missing keys', () => {
+      const cache = new TTLCache<string>();
+      expect(cache.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should delete values', () => {
+      const cache = new TTLCache<string>();
+      cache.set('key1', 'value1');
+      expect(cache.delete('key1')).toBe(true);
+      expect(cache.get('key1')).toBeUndefined();
+    });
+
+    it('should clear all values', () => {
+      const cache = new TTLCache<string>();
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+      cache.clear();
+      expect(cache.size).toBe(0);
+    });
+
+    it('should check if key exists', () => {
+      const cache = new TTLCache<string>();
+      cache.set('key1', 'value1');
+      expect(cache.has('key1')).toBe(true);
+      expect(cache.has('key2')).toBe(false);
+    });
+  });
+
+  describe('TTL expiration', () => {
+    it('should expire entries after TTL', () => {
+      const cache = new TTLCache<string>({ ttlMs: 1000 });
+      cache.set('key1', 'value1');
+
+      // Before expiration
+      expect(cache.get('key1')).toBe('value1');
+
+      // After expiration
+      vi.advanceTimersByTime(1001);
+      expect(cache.get('key1')).toBeUndefined();
+    });
+
+    it('should refresh TTL on access', () => {
+      const cache = new TTLCache<string>({ ttlMs: 1000 });
+      cache.set('key1', 'value1');
+
+      // Access at 500ms - should refresh TTL
+      vi.advanceTimersByTime(500);
+      expect(cache.get('key1')).toBe('value1');
+
+      // 500ms later (1000ms from last access) - should still be valid
+      vi.advanceTimersByTime(500);
+      expect(cache.get('key1')).toBe('value1');
+
+      // 1001ms from last access - should expire
+      vi.advanceTimersByTime(1001);
+      expect(cache.get('key1')).toBeUndefined();
+    });
+
+    it('should report expired keys as not existing', () => {
+      const cache = new TTLCache<string>({ ttlMs: 1000 });
+      cache.set('key1', 'value1');
+
+      vi.advanceTimersByTime(1001);
+      expect(cache.has('key1')).toBe(false);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('should evict oldest entry when at capacity', () => {
+      const cache = new TTLCache<string>({ maxSize: 2 });
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+      cache.set('key3', 'value3'); // Should evict key1
+
+      expect(cache.get('key1')).toBeUndefined();
+      expect(cache.get('key2')).toBe('value2');
+      expect(cache.get('key3')).toBe('value3');
+    });
+
+    it('should update LRU order on access', () => {
+      const cache = new TTLCache<string>({ maxSize: 2 });
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+
+      // Access key1, making key2 the oldest
+      cache.get('key1');
+
+      cache.set('key3', 'value3'); // Should evict key2
+
+      expect(cache.get('key1')).toBe('value1');
+      expect(cache.get('key2')).toBeUndefined();
+      expect(cache.get('key3')).toBe('value3');
+    });
+
+    it('should evict expired entries before size-based eviction', () => {
+      const cache = new TTLCache<string>({ maxSize: 2, ttlMs: 1000 });
+      cache.set('key1', 'value1');
+
+      vi.advanceTimersByTime(1001); // key1 expires
+
+      cache.set('key2', 'value2');
+      cache.set('key3', 'value3'); // key1 already expired, no eviction of key2
+
+      expect(cache.get('key1')).toBeUndefined();
+      expect(cache.get('key2')).toBe('value2');
+      expect(cache.get('key3')).toBe('value3');
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return cache statistics', () => {
+      const cache = new TTLCache<string>({ maxSize: 50, ttlMs: 30000 });
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+
+      const stats = cache.getStats();
+      expect(stats.size).toBe(2);
+      expect(stats.maxSize).toBe(50);
+      expect(stats.ttlMs).toBe(30000);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should remove expired entries and return count', () => {
+      const cache = new TTLCache<string>({ ttlMs: 1000 });
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+
+      vi.advanceTimersByTime(1001);
+
+      // Call cleanup directly without any other operations
+      const removed = cache.cleanup();
+      expect(removed).toBe(2);
+      expect(cache.size).toBe(0);
+    });
+
+    it('should not affect non-expired entries', () => {
+      const cache = new TTLCache<string>({ ttlMs: 1000 });
+      cache.set('key1', 'value1');
+
+      vi.advanceTimersByTime(500); // Only half the TTL
+
+      const removed = cache.cleanup();
+      expect(removed).toBe(0);
+      expect(cache.size).toBe(1);
+      expect(cache.get('key1')).toBe('value1');
+    });
+  });
+
+  describe('default options', () => {
+    it('should use default maxSize of 100', () => {
+      const cache = new TTLCache<string>();
+      const stats = cache.getStats();
+      expect(stats.maxSize).toBe(100);
+    });
+
+    it('should use default TTL of 1 hour', () => {
+      const cache = new TTLCache<string>();
+      const stats = cache.getStats();
+      expect(stats.ttlMs).toBe(60 * 60 * 1000);
+    });
+  });
+});

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,163 @@
+/**
+ * Generic TTL-based LRU cache with configurable size and expiration.
+ * Provides a reusable caching utility for embeddings, metadata, and other data.
+ */
+
+interface CacheEntry<T> {
+  value: T;
+  timestamp: number;
+}
+
+export interface CacheOptions {
+  /** Maximum number of entries (default: 100) */
+  maxSize?: number;
+  /** Time-to-live in milliseconds (default: 1 hour) */
+  ttlMs?: number;
+}
+
+const DEFAULT_MAX_SIZE = 100;
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * A generic LRU cache with TTL-based expiration.
+ *
+ * Features:
+ * - Configurable max size with LRU eviction
+ * - TTL-based expiration for entries
+ * - Automatic cleanup of expired entries on access
+ * - Thread-safe for single-threaded Node.js
+ *
+ * @example
+ * ```typescript
+ * const cache = new TTLCache<number[]>({ maxSize: 50, ttlMs: 30000 });
+ * cache.set('key', [1, 2, 3]);
+ * const value = cache.get('key'); // [1, 2, 3] or undefined if expired
+ * ```
+ */
+export class TTLCache<T> {
+  private cache: Map<string, CacheEntry<T>> = new Map();
+  private readonly maxSize: number;
+  private readonly ttlMs: number;
+
+  constructor(options: CacheOptions = {}) {
+    this.maxSize = options.maxSize ?? DEFAULT_MAX_SIZE;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Get a value from the cache.
+   * Returns undefined if not found or expired.
+   * Updates access time for LRU tracking.
+   */
+  get(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    const now = Date.now();
+    if (now - entry.timestamp > this.ttlMs) {
+      // Entry expired
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    // Move to end for LRU (delete and re-insert with updated timestamp)
+    this.cache.delete(key);
+    this.cache.set(key, { value: entry.value, timestamp: now });
+    return entry.value;
+  }
+
+  /**
+   * Set a value in the cache.
+   * Evicts expired entries and oldest entry if at capacity.
+   */
+  set(key: string, value: T): void {
+    const now = Date.now();
+
+    // Remove existing entry if present (will be re-added at end)
+    this.cache.delete(key);
+
+    // Evict expired entries first
+    this.evictExpired(now);
+
+    // Evict oldest entry if still at capacity
+    if (this.cache.size >= this.maxSize) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+      }
+    }
+
+    // Add new entry
+    this.cache.set(key, { value, timestamp: now });
+  }
+
+  /**
+   * Check if a key exists and is not expired.
+   */
+  has(key: string): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return false;
+    }
+    if (Date.now() - entry.timestamp > this.ttlMs) {
+      this.cache.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Delete a specific key from the cache.
+   */
+  delete(key: string): boolean {
+    return this.cache.delete(key);
+  }
+
+  /**
+   * Clear all entries from the cache.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Get the current number of entries (including potentially expired ones).
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * Get cache statistics.
+   */
+  getStats(): { size: number; maxSize: number; ttlMs: number } {
+    return {
+      size: this.cache.size,
+      maxSize: this.maxSize,
+      ttlMs: this.ttlMs,
+    };
+  }
+
+  /**
+   * Evict all expired entries.
+   */
+  private evictExpired(now: number = Date.now()): void {
+    for (const [key, entry] of this.cache) {
+      if (now - entry.timestamp > this.ttlMs) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Force cleanup of all expired entries.
+   * Useful for periodic maintenance.
+   */
+  cleanup(): number {
+    const sizeBefore = this.cache.size;
+    this.evictExpired();
+    return sizeBefore - this.cache.size;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a generic, reusable TTL-based LRU cache utility and refactors the indexer to use it.

### Changes
- Added `src/utils/cache.ts` with `TTLCache<T>` class featuring:
  - Configurable max size with LRU eviction
  - TTL-based expiration for entries
  - Methods: `get`, `set`, `has`, `delete`, `clear`, `cleanup`, `getStats`
- Refactored `CodeIndexer` to use `TTLCache<number[]>` for query embeddings
- Removed duplicate TTL/LRU logic from indexer (43 lines → 10 lines)
- Added comprehensive tests (16 test cases)

### Why
The previous query embedding cache had custom TTL/LRU logic inline in the indexer. This extracts it into a reusable utility that can be used for other caches (clustering metadata, etc.) with consistent behavior.

### Usage
```typescript
import { TTLCache } from './utils/cache.js';

const cache = new TTLCache<MyType>({ maxSize: 50, ttlMs: 30000 });
cache.set('key', value);
const value = cache.get('key'); // undefined if expired
```

## Test plan
- [x] All 676 tests pass (16 new cache tests)
- [x] TypeScript build succeeds
- [x] Existing cache behavior preserved