### PR TITLE
feat: add configurable rate limiting for embedding batches

### DIFF
--- a/src/__tests__/search/indexer.test.ts
+++ b/src/__tests__/search/indexer.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../config.js', async (_importOriginal) => {
     getDefaultExcludePatterns: vi.fn().mockReturnValue(['**/node_modules/**']),
     getChunkingConfig: vi.fn().mockReturnValue({ maxLines: 100, overlap: 20 }),
     getSearchConfig: vi.fn().mockReturnValue({ semanticWeight: 0.7, keywordWeight: 0.3 }),
+    getIndexingConfig: vi.fn().mockReturnValue({ batchSize: 32, batchDelayMs: 0 }),
   };
 });
 
@@ -60,6 +61,7 @@ describe('CodeIndexer', () => {
       semanticWeight: 0.7,
       keywordWeight: 0.3,
     });
+    vi.mocked(configModule.getIndexingConfig).mockReturnValue({ batchSize: 32, batchDelayMs: 0 });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Adds `IndexingConfig` with `batchDelayMs` and `batchSize` options to control embedding API rate limiting
- Configurable via `.lance-context.json` under the `indexing` section
- Default: 32 chunks per batch with 0ms delay (preserves current behavior)

## Configuration Example
```json
{
  "indexing": {
    "batchSize": 20,
    "batchDelayMs": 500
  }
}
```

## Test plan
- [x] All 692 tests pass
- [x] Build succeeds
- [ ] Manual test with different delay values

🤖 Generated with [Claude Code](https://claude.com/claude-code)