### PR TITLE
fix: type progressUpdates array in indexer test

### DIFF
--- a/src/__tests__/search/indexer.test.ts
+++ b/src/__tests__/search/indexer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { CodeIndexer } from '../../search/indexer.js';
+import { CodeIndexer, type IndexProgress } from '../../search/indexer.js';
 import { createMockEmbeddingBackend } from '../mocks/embedding-backend.mock.js';
 import { createMockConnection, createMockTable } from '../mocks/lancedb.mock.js';
 
@@ -876,7 +876,7 @@ describe('CodeIndexer', () => {
       const indexer = new CodeIndexer('/project', mockBackend);
       await indexer.initialize();
 
-      const progressUpdates: any[] = [];
+      const progressUpdates: IndexProgress[] = [];
       await indexer.indexCodebase(undefined, undefined, false, (progress) => {
         progressUpdates.push(progress);
       });


### PR DESCRIPTION
## Summary
- Type `progressUpdates` array with proper `IndexProgress` type instead of `any[]`
- Add type import from indexer module

## Analysis of `any` types in tests

Most `any` types in test files are **necessary for vitest mocking**:

- **LanceDB mocks**: `mockConnection.openTable.mockResolvedValue(mockTable as any)` - Required because mocking partial implementations of complex LanceDB types
- **Node exec mocks**: `(cmd: string, opts: any, callback?: any)` - Required due to Node's complex overloaded exec signatures
- **fs mocks**: `vi.mocked(fsPromises.stat).mockResolvedValue({ mtimeMs: Date.now() } as any)` - Required when returning partial stat objects

The only cleanly typeable `any` was `progressUpdates: any[]` which is now properly typed.

## Test plan
- [x] All 724 tests pass
- [x] Type checking passes (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)