### PR TITLE
feat: add structured logging utility with log levels

### DIFF
--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from '../../utils/logger.js';
+
+describe('logger', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('log levels', () => {
+    it('should default to info level', () => {
+      delete process.env.LANCE_CONTEXT_LOG_LEVEL;
+      delete process.env.LANCE_CONTEXT_DEBUG;
+      expect(logger.getLevel()).toBe('info');
+    });
+
+    it('should respect LANCE_CONTEXT_LOG_LEVEL', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      expect(logger.getLevel()).toBe('debug');
+    });
+
+    it('should respect LANCE_CONTEXT_DEBUG for backward compatibility', () => {
+      delete process.env.LANCE_CONTEXT_LOG_LEVEL;
+      process.env.LANCE_CONTEXT_DEBUG = '1';
+      expect(logger.getLevel()).toBe('debug');
+    });
+
+    it('should prefer LOG_LEVEL over DEBUG', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'warn';
+      process.env.LANCE_CONTEXT_DEBUG = '1';
+      expect(logger.getLevel()).toBe('warn');
+    });
+
+    it('should ignore invalid log levels', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'invalid';
+      delete process.env.LANCE_CONTEXT_DEBUG;
+      expect(logger.getLevel()).toBe('info');
+    });
+  });
+
+  describe('debug()', () => {
+    it('should not log when level is info', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'info';
+      logger.debug('test message');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should log when level is debug', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      logger.debug('test message');
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should include context when provided', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      logger.debug('test message', 'indexer');
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('[indexer]'));
+    });
+
+    it('should log data object when provided', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      logger.debug('test message', undefined, { key: 'value' });
+      expect(console.error).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('info()', () => {
+    it('should log when level is info', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'info';
+      logger.info('test message');
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should not log when level is warn', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'warn';
+      logger.info('test message');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('warn()', () => {
+    it('should log when level is warn', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'warn';
+      logger.warn('test message');
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should not log when level is error', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'error';
+      logger.warn('test message');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error()', () => {
+    it('should log when level is error', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'error';
+      logger.error('test message');
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should not log when level is silent', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'silent';
+      logger.error('test message');
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should log Error object details', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'error';
+      logger.error('test message', undefined, new Error('test error'));
+      expect(console.error).toHaveBeenCalledTimes(2);
+    });
+
+    it('should include stack trace in debug mode', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      const error = new Error('test error');
+      logger.error('test message', undefined, error);
+      expect(console.error).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('isDebugEnabled()', () => {
+    it('should return true when level is debug', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'debug';
+      expect(logger.isDebugEnabled()).toBe(true);
+    });
+
+    it('should return false when level is info', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'info';
+      expect(logger.isDebugEnabled()).toBe(false);
+    });
+  });
+
+  describe('message formatting', () => {
+    it('should include [lance-context] prefix', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'info';
+      logger.info('test message');
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('[lance-context]'));
+    });
+
+    it('should include level tag', () => {
+      process.env.LANCE_CONTEXT_LOG_LEVEL = 'info';
+      logger.info('test message');
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('INFO'));
+    });
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,126 @@
+/**
+ * Structured logging utility for lance-context.
+ *
+ * Supports log levels (debug, info, warn, error) configured via environment variable.
+ */
+
+/** Available log levels in order of severity */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+/** Numeric values for log level comparison */
+const LOG_LEVEL_VALUES: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+/** Default log level when not configured */
+const DEFAULT_LOG_LEVEL: LogLevel = 'info';
+
+/** Prefix used for all log messages */
+const LOG_PREFIX = '[lance-context]';
+
+/**
+ * Get the configured log level from environment.
+ */
+function getLogLevel(): LogLevel {
+  const envLevel = process.env.LANCE_CONTEXT_LOG_LEVEL?.toLowerCase();
+
+  if (envLevel && envLevel in LOG_LEVEL_VALUES) {
+    return envLevel as LogLevel;
+  }
+
+  // Support legacy debug mode
+  if (process.env.LANCE_CONTEXT_DEBUG === '1' || process.env.LANCE_CONTEXT_DEBUG === 'true') {
+    return 'debug';
+  }
+
+  return DEFAULT_LOG_LEVEL;
+}
+
+/**
+ * Check if a log level should be output given current configuration.
+ */
+function shouldLog(level: LogLevel): boolean {
+  const currentLevel = getLogLevel();
+  return LOG_LEVEL_VALUES[level] >= LOG_LEVEL_VALUES[currentLevel];
+}
+
+/**
+ * Format a log message with optional context.
+ */
+function formatMessage(level: LogLevel, message: string, context?: string): string {
+  const levelTag = level.toUpperCase().padEnd(5);
+  const contextTag = context ? `[${context}]` : '';
+  return `${LOG_PREFIX} ${levelTag} ${contextTag} ${message}`.trim();
+}
+
+/**
+ * Logger instance for structured logging.
+ */
+export const logger = {
+  /**
+   * Log debug information. Only shown when LANCE_CONTEXT_LOG_LEVEL=debug.
+   */
+  debug(message: string, context?: string, data?: Record<string, unknown>): void {
+    if (!shouldLog('debug')) return;
+    console.error(formatMessage('debug', message, context));
+    if (data) {
+      console.error(`${LOG_PREFIX}       `, JSON.stringify(data, null, 2));
+    }
+  },
+
+  /**
+   * Log informational messages. Default level.
+   */
+  info(message: string, context?: string, data?: Record<string, unknown>): void {
+    if (!shouldLog('info')) return;
+    console.error(formatMessage('info', message, context));
+    if (data) {
+      console.error(`${LOG_PREFIX}       `, JSON.stringify(data, null, 2));
+    }
+  },
+
+  /**
+   * Log warning messages.
+   */
+  warn(message: string, context?: string, data?: Record<string, unknown>): void {
+    if (!shouldLog('warn')) return;
+    console.error(formatMessage('warn', message, context));
+    if (data) {
+      console.error(`${LOG_PREFIX}       `, JSON.stringify(data, null, 2));
+    }
+  },
+
+  /**
+   * Log error messages.
+   */
+  error(message: string, context?: string, error?: unknown): void {
+    if (!shouldLog('error')) return;
+    console.error(formatMessage('error', message, context));
+    if (error instanceof Error) {
+      console.error(`${LOG_PREFIX}       `, error.message);
+      if (getLogLevel() === 'debug' && error.stack) {
+        console.error(`${LOG_PREFIX}       `, error.stack);
+      }
+    } else if (error !== undefined) {
+      console.error(`${LOG_PREFIX}       `, error);
+    }
+  },
+
+  /**
+   * Get current log level.
+   */
+  getLevel(): LogLevel {
+    return getLogLevel();
+  },
+
+  /**
+   * Check if debug logging is enabled.
+   */
+  isDebugEnabled(): boolean {
+    return shouldLog('debug');
+  },
+};


### PR DESCRIPTION
## Summary
- Add `src/utils/logger.ts` with structured logging utility
- Support log levels: debug, info, warn, error, silent
- Configure via `LANCE_CONTEXT_LOG_LEVEL` environment variable
- Backward compatible with `LANCE_CONTEXT_DEBUG=1`
- Includes 21 comprehensive tests

## Features
- **Log levels**: debug → info → warn → error → silent
- **Consistent formatting**: `[lance-context] LEVEL [context] message`
- **Structured data**: Optional data objects logged as JSON
- **Error handling**: Error objects logged with optional stack traces in debug mode

## Usage
```typescript
import { logger } from './utils/logger.js';

logger.debug('detailed info', 'indexer');
logger.info('operation complete', 'search', { results: 42 });
logger.warn('something unexpected');
logger.error('failed operation', 'embedding', error);
```

## Configuration
```bash
# Set log level (default: info)
LANCE_CONTEXT_LOG_LEVEL=debug  # debug, info, warn, error, silent

# Legacy support
LANCE_CONTEXT_DEBUG=1  # equivalent to LOG_LEVEL=debug
```

## Test plan
- [x] All 745 tests pass
- [x] Type checking passes
- [x] 21 new tests for logger utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)