### PR TITLE
fix: wrap SSE event listeners with try-catch

### DIFF
--- a/src/dashboard/events.ts
+++ b/src/dashboard/events.ts
@@ -18,27 +18,48 @@ export class SSEManager {
   }
 
   /**
-   * Set up listeners for dashboard state events
+   * Set up listeners for dashboard state events.
+   * Each listener is wrapped in try-catch to prevent unhandled rejections.
    */
   private setupEventListeners(): void {
     dashboardState.on('progress', (progress) => {
-      this.broadcast('indexing:progress', progress);
+      try {
+        this.broadcast('indexing:progress', progress);
+      } catch {
+        // Ignore broadcast failures - clients will reconnect
+      }
     });
 
     dashboardState.on('indexing:start', () => {
-      this.broadcast('indexing:start', { timestamp: new Date().toISOString() });
+      try {
+        this.broadcast('indexing:start', { timestamp: new Date().toISOString() });
+      } catch {
+        // Ignore broadcast failures
+      }
     });
 
     dashboardState.on('indexing:complete', (result) => {
-      this.broadcast('indexing:complete', result);
+      try {
+        this.broadcast('indexing:complete', result);
+      } catch {
+        // Ignore broadcast failures
+      }
     });
 
     dashboardState.on('status:change', (status) => {
-      this.broadcast('status:change', status);
+      try {
+        this.broadcast('status:change', status);
+      } catch {
+        // Ignore broadcast failures
+      }
     });
 
     dashboardState.on('usage:update', (usage) => {
-      this.broadcast('usage:update', usage);
+      try {
+        this.broadcast('usage:update', usage);
+      } catch {
+        // Ignore broadcast failures
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
Wrap all SSE event listeners in try-catch to prevent unhandled exceptions.

## Problem
Event listeners in `SSEManager.setupEventListeners()` could throw if:
- `JSON.stringify()` fails on circular data
- Broadcast throws unexpectedly

This would cause unhandled rejections that could crash the SSE manager.

## Solution
Wrap each listener callback in try-catch. Failures are silently ignored since:
- Clients will reconnect automatically
- These are non-critical real-time updates

## Test plan
- [x] All 745 tests pass
- [x] Type checking passes

Closes lance-context-4f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)