### PR TITLE
feat: switch default Ollama model to qwen3-embedding

### DIFF
--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -1,10 +1,10 @@
 import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
-import { OllamaBackend } from './ollama.js';
+import { OllamaBackend, DEFAULT_OLLAMA_MODEL } from './ollama.js';
 import { JinaBackend } from './jina.js';
 
 export * from './types.js';
 export { chunkArray } from './types.js';
-export { OllamaBackend } from './ollama.js';
+export { OllamaBackend, DEFAULT_OLLAMA_MODEL } from './ollama.js';
 export { JinaBackend } from './jina.js';
 export { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 
@@ -33,7 +33,7 @@ export async function createEmbeddingBackend(
 ): Promise<EmbeddingBackend> {
   const jinaKey = config?.apiKey || process.env.JINA_API_KEY;
   const ollamaUrl = config?.baseUrl || process.env.OLLAMA_URL || 'http://localhost:11434';
-  const ollamaModel = config?.model || 'nomic-embed-text';
+  const ollamaModel = config?.model || DEFAULT_OLLAMA_MODEL;
 
   // If explicit backend is specified, use only that backend
   if (config?.backend && config.backend !== 'local') {

--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -5,6 +5,19 @@ import { fetchWithRetry } from './retry.js';
 /** Default parallel batch size for Ollama (concurrent requests) */
 const DEFAULT_BATCH_SIZE = 10;
 
+/** Default Ollama model optimized for code search */
+export const DEFAULT_OLLAMA_MODEL = 'qwen3-embedding:0.6b';
+
+/** Model dimension defaults (used when dimensions can't be auto-detected) */
+const MODEL_DIMENSIONS: Record<string, number> = {
+  'qwen3-embedding:0.6b': 1024,
+  'qwen3-embedding:4b': 1024,
+  'qwen3-embedding:8b': 1024,
+  'nomic-embed-text': 768,
+  'mxbai-embed-large': 1024,
+  'all-minilm': 384,
+};
+
 /**
  * Ollama embedding backend
  * Uses local Ollama server for embeddings
@@ -13,24 +26,54 @@ export class OllamaBackend implements EmbeddingBackend {
   name = 'ollama';
   private model: string;
   private baseUrl: string;
-  private dimensions = 768; // nomic-embed-text default
+  private dimensions: number;
   private batchSize: number;
 
   constructor(config: EmbeddingConfig) {
-    this.model = config.model || 'nomic-embed-text';
+    this.model = config.model || DEFAULT_OLLAMA_MODEL;
     this.baseUrl = config.baseUrl || 'http://localhost:11434';
     this.batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+    // Set dimensions based on known models, default to 1024 for unknown models
+    this.dimensions = MODEL_DIMENSIONS[this.model] ?? 1024;
   }
 
   async initialize(): Promise<void> {
-    // Test connection
+    // Test connection and check if model is available
     try {
       const response = await fetchWithRetry(`${this.baseUrl}/api/tags`, {});
       if (!response.ok) {
         throw new Error(`Ollama server returned ${response.status}`);
       }
+
+      // Check if our model is available
+      const data = (await response.json()) as { models?: Array<{ name: string }> };
+      const availableModels = data.models?.map((m) => m.name) || [];
+      const modelAvailable = availableModels.some(
+        (name) => name === this.model || name.startsWith(`${this.model}:`)
+      );
+
+      if (!modelAvailable) {
+        throw new Error(
+          `Model '${this.model}' not found in Ollama.\n\n` +
+            `To install it, run:\n` +
+            `  ollama pull ${this.model}\n\n` +
+            `Available models: ${availableModels.length > 0 ? availableModels.join(', ') : 'none'}\n\n` +
+            `For best code search results, we recommend:\n` +
+            `  ollama pull ${DEFAULT_OLLAMA_MODEL}`
+        );
+      }
     } catch (error) {
-      throw new Error(`Failed to connect to Ollama at ${this.baseUrl}: ${error}`);
+      if (error instanceof Error && error.message.includes('Model')) {
+        throw error; // Re-throw model not found errors as-is
+      }
+      throw new Error(
+        `Failed to connect to Ollama at ${this.baseUrl}.\n\n` +
+          `Make sure Ollama is installed and running:\n` +
+          `  1. Install Ollama from https://ollama.com\n` +
+          `  2. Start Ollama (it runs in the background)\n` +
+          `  3. Pull the embedding model: ollama pull ${DEFAULT_OLLAMA_MODEL}\n\n` +
+          `Original error: ${error}`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Change default Ollama embedding model from `nomic-embed-text` to `qwen3-embedding:0.6b`
- Add model availability checking with helpful error messages
- Add dynamic dimension lookup for known models (qwen3, nomic, mxbai, all-minilm)
- Update README with comprehensive Ollama setup instructions

## Why
Users were hitting Jina API rate limits during initial codebase indexing. The new default model:
- Runs locally via Ollama (no API limits)
- Has explicit code retrieval capabilities
- Ranks #1 on MTEB multilingual leaderboard
- Supports 32K token context (vs 2K for nomic-embed-text)

## Test plan
- [x] All 1196 tests pass
- [x] Build succeeds
- [ ] Manual test: `ollama pull qwen3-embedding:0.6b` then index a codebase