### PR TITLE
fix: reduce concurrency limits to prevent Ollama overload

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ const EmbeddingConfigSchema = z.object({
   backend: z.enum(['jina', 'ollama']).optional(),
   model: z.string().optional(),
   /** Number of concurrent requests to Ollama (default: 10). Increase if your system has capacity. */
-  ollamaConcurrency: z.number().min(1).max(2000).optional(),
+  ollamaConcurrency: z.number().min(1).max(200).optional(),
 });
 
 const DashboardConfigSchema = z.object({
@@ -718,7 +718,7 @@ export async function getEmbeddingSettings(projectPath: string): Promise<{
     backend: config.embedding?.backend || 'auto',
     hasApiKey: !!(secrets.jinaApiKey || process.env.JINA_API_KEY),
     ollamaUrl: process.env.OLLAMA_URL || 'http://localhost:11434',
-    ollamaConcurrency: config.embedding?.ollamaConcurrency || 200,
+    ollamaConcurrency: config.embedding?.ollamaConcurrency || 100,
     batchSize: config.indexing?.batchSize || DEFAULT_INDEXING.batchSize,
   };
 }

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -844,12 +844,11 @@ export function getDashboardHTML(): string {
             <label for="concurrencySelect">Ollama Concurrency</label>
             <select id="concurrencySelect" class="form-select">
               <option value="10">10 (conservative)</option>
+              <option value="25">25</option>
               <option value="50">50</option>
-              <option value="100">100</option>
-              <option value="200" selected>200 (default)</option>
-              <option value="500">500</option>
-              <option value="1000">1000 (high-end)</option>
-              <option value="2000">2000 (maximum)</option>
+              <option value="100" selected>100 (default)</option>
+              <option value="150">150</option>
+              <option value="200">200 (maximum)</option>
             </select>
           </div>
           <div class="form-group" id="batchSizeGroup">

--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -3,7 +3,7 @@ import { chunkArray } from './types.js';
 import { fetchWithRetry } from './retry.js';
 
 /** Default parallel batch size for Ollama (concurrent requests) */
-const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_BATCH_SIZE = 100;
 
 /** Default Ollama model optimized for code search */
 export const DEFAULT_OLLAMA_MODEL = 'qwen3-embedding:0.6b';


### PR DESCRIPTION
## Summary

- Reduce max concurrency from 2000 to 200 (Ollama can't handle thousands of concurrent connections)
- Reduce default concurrency from 200 to 100
- Update dashboard dropdown options: 10, 25, 50, 100 (default), 150, 200 (max)

High concurrency values (500+) were causing Ollama to hang or time out.