### PR TITLE
feat: use Ollama batch embedding API for faster indexing

### DIFF
--- a/src/__tests__/mocks/fetch.mock.ts
+++ b/src/__tests__/mocks/fetch.mock.ts
@@ -87,7 +87,7 @@ export function createJinaEmbeddingResponse(embeddings: number[][]): MockFetchRe
 }
 
 /**
- * Creates Ollama-style embedding response
+ * Creates Ollama-style embedding response (legacy single embedding)
  */
 export function createOllamaEmbeddingResponse(embedding: number[]): MockFetchResponse {
   return {
@@ -95,5 +95,17 @@ export function createOllamaEmbeddingResponse(embedding: number[]): MockFetchRes
     status: 200,
     json: async () => ({ embedding }),
     text: async () => JSON.stringify({ embedding }),
+  };
+}
+
+/**
+ * Creates Ollama-style batch embedding response (/api/embed)
+ */
+export function createOllamaBatchEmbeddingResponse(embeddings: number[][]): MockFetchResponse {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ embeddings }),
+    text: async () => JSON.stringify({ embeddings }),
   };
 }


### PR DESCRIPTION
## Summary

Switch from `/api/embeddings` (single text) to `/api/embed` (batch) API.

**Before:** 52,000 chunks = 52,000 HTTP requests  
**After:** 52,000 chunks = ~520 HTTP requests (with batch size 100)

This should reduce indexing time by 10-50x depending on network latency.

### Changes
- `embedBatch()` now sends array of texts in single request
- `embed()` delegates to `embedBatch()` with single-element array
- Response format changed from `{ embedding: [...] }` to `{ embeddings: [[...], ...] }`
- Updated tests to match new batch API behavior