### PR TITLE
feat: add parallel batch processing to Ollama backend

### DIFF
--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -35,6 +35,7 @@ export async function createEmbeddingBackend(
   const ollamaUrl = config?.baseUrl || process.env.OLLAMA_URL || 'http://localhost:11434';
   const ollamaModel = config?.model || DEFAULT_OLLAMA_MODEL;
   const ollamaBatchSize = config?.batchSize;
+  const ollamaConcurrency = config?.concurrency;
 
   // If explicit backend is specified, use only that backend
   if (config?.backend && config.backend !== 'local') {
@@ -54,6 +55,7 @@ export async function createEmbeddingBackend(
         baseUrl: ollamaUrl,
         model: ollamaModel,
         batchSize: ollamaBatchSize,
+        concurrency: ollamaConcurrency,
       });
       await backend.initialize();
       console.error(`[lance-context] Using ollama embedding backend (explicitly configured)`);
@@ -77,6 +79,7 @@ export async function createEmbeddingBackend(
         baseUrl: ollamaUrl,
         model: ollamaModel,
         batchSize: ollamaBatchSize,
+        concurrency: ollamaConcurrency,
       })
   );
 

--- a/src/embeddings/types.ts
+++ b/src/embeddings/types.ts
@@ -66,9 +66,16 @@ export interface EmbeddingConfig {
    * Maximum number of texts to process in a single batch request.
    * Large batches are automatically split into smaller chunks to prevent
    * timeouts, memory issues, and API rate limit errors.
-   * Default: 100 for Jina, 10 for Ollama (parallel requests)
+   * Default: 100 for Jina, 100 for Ollama
    */
   batchSize?: number;
+
+  /**
+   * Maximum number of concurrent batch requests (Ollama only).
+   * Controls how many batch requests are sent in parallel.
+   * Default: 4 for Ollama
+   */
+  concurrency?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `concurrency` config option to control parallel batch requests
- Process batches in parallel groups using Promise.all for faster indexing
- Default concurrency is 4 (process up to 4 batch requests in parallel)
- Re-enables the `ollamaConcurrency` setting which became unused after the batch API change

## Test plan
- [x] Existing Ollama tests pass
- [x] New tests verify parallel batch processing works correctly
- [x] New tests verify result order is preserved with parallel processing
- [x] Full test suite passes (1199 tests)
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)