### PR TITLE
fix: pass correct batchSize and concurrency to embedding backend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -332,7 +332,8 @@ async function getIndexer(): Promise<CodeIndexer> {
       const backend = await createEmbeddingBackend({
         backend: config.embedding?.backend,
         apiKey: secrets.jinaApiKey,
-        batchSize: config.embedding?.ollamaConcurrency,
+        batchSize: config.indexing?.batchSize,
+        concurrency: config.embedding?.ollamaConcurrency,
       });
       const idx = new CodeIndexer(PROJECT_PATH, backend);
       await idx.initialize();


### PR DESCRIPTION
## Summary
- Fixed bug where `ollamaConcurrency` config was incorrectly passed as `batchSize`
- Now correctly passes `config.indexing?.batchSize` as `batchSize`
- Now correctly passes `config.embedding?.ollamaConcurrency` as `concurrency`

## Problem
Dashboard settings for Ollama Concurrency (e.g., 100) were being ignored, causing parallel batch processing to default to 4 concurrent requests instead of the configured value. This resulted in ~6+ hour ETAs for large codebases instead of the expected faster indexing.

## Test plan
- [x] TypeScript type check passes
- [x] All 25 Ollama embedding tests pass
- [ ] Manual test: Re-index large codebase and verify ETA improves with configured concurrency

🤖 Generated with [Claude Code](https://claude.ai/code)