### PR TITLE
fix: add initial embedding progress message and reduce batch size

### DIFF
--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -1419,12 +1419,21 @@ export class CodeIndexer {
       : { batchSize: 200, batchDelayMs: 0 };
     const { batchDelayMs } = indexingConfig;
 
-    // Use large batch size (10k) to maximize parallelization in embedding backend
+    // Use batch size of 2000 to balance parallelization with progress visibility
     // The embedding backend will split into smaller batches and process in parallel
-    const embeddingBatchSize = 10000;
+    // With Ollama defaults (batchSize=100, concurrency=100), 2000 = 20 batches = 1 parallel round
+    const embeddingBatchSize = 2000;
 
     const startTime = Date.now();
     let processedChunks = 0;
+
+    // Report initial progress so user knows embedding has started
+    report({
+      phase: 'embedding',
+      current: 0,
+      total: chunks.length,
+      message: `Starting embedding of ${chunks.length} chunks...`,
+    });
 
     for (let i = 0; i < chunks.length; i += embeddingBatchSize) {
       const batch = chunks.slice(i, i + embeddingBatchSize);


### PR DESCRIPTION
## Summary

- Add "Starting embedding of N chunks..." message immediately when embedding begins
- Reduce `embeddingBatchSize` from 10000 to 2000 for more frequent progress updates
- With 52k chunks, users now see progress every ~2k instead of waiting for 10k to complete

This fixes the issue where users would see "Created 52016 chunks" and then no visible progress for a long time while the first large batch was being processed.

## Test plan

- [ ] Start indexing a large codebase (e.g., centrifuge)
- [ ] Verify "Starting embedding of N chunks..." appears immediately after "Created N chunks"
- [ ] Verify progress updates appear every ~2000 chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)