### PR TITLE
feat: stream server-side logs to dashboard browser console

### DIFF
--- a/src/dashboard/events.ts
+++ b/src/dashboard/events.ts
@@ -189,6 +189,17 @@ export class SSEManager {
 }
 
 /**
+ * Broadcast a log message to all connected dashboard clients
+ */
+export function broadcastLog(level: 'info' | 'warn' | 'error', message: string): void {
+  sseManager.broadcast('server:log', {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
  * Singleton instance of the SSE manager
  */
 export const sseManager = new SSEManager();

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -1742,6 +1742,24 @@ export function getDashboardHTML(): string {
         // Just keep connection alive - don't log to reduce noise
       });
 
+      eventSource.addEventListener('server:log', (e) => {
+        const logData = JSON.parse(e.data);
+        const prefix = '%c[server]%c ';
+        const prefixStyle = 'color: #a371f7; font-weight: bold';
+        const msgStyle = 'color: inherit';
+
+        switch (logData.level) {
+          case 'error':
+            console.error(prefix + logData.message, prefixStyle, msgStyle);
+            break;
+          case 'warn':
+            console.warn(prefix + logData.message, prefixStyle, msgStyle);
+            break;
+          default:
+            console.log(prefix + logData.message, prefixStyle, msgStyle);
+        }
+      });
+
       eventSource.onerror = (e) => {
         log.warn('SSE connection error, will reconnect...', e);
         setConnected(false);

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { EmbeddingBackend } from '../embeddings/index.js';
+import { broadcastLog } from '../dashboard/events.js';
 import { ASTChunker } from './ast-chunker.js';
 import { TreeSitterChunker } from './tree-sitter-chunker.js';
 import {
@@ -1438,9 +1439,9 @@ export class CodeIndexer {
     for (let i = 0; i < chunks.length; i += embeddingBatchSize) {
       const batch = chunks.slice(i, i + embeddingBatchSize);
       const texts = batch.map((c) => c.content);
-      console.error(
-        `[lance-context] Sending ${texts.length} texts to embedding backend (batch ${Math.floor(i / embeddingBatchSize) + 1}/${Math.ceil(chunks.length / embeddingBatchSize)})...`
-      );
+      const batchMsg = `Sending ${texts.length} texts to embedding backend (batch ${Math.floor(i / embeddingBatchSize) + 1}/${Math.ceil(chunks.length / embeddingBatchSize)})...`;
+      console.error(`[lance-context] ${batchMsg}`);
+      broadcastLog('info', batchMsg);
       const embeddings = await this.embeddingBackend.embedBatch(texts);
       batch.forEach((chunk, idx) => {
         chunk.embedding = embeddings[idx];


### PR DESCRIPTION
## Summary
- Add `broadcastLog` function to send server-side log messages via SSE
- Add `server:log` event listener in dashboard UI to display logs in browser console
- Stream indexing progress from Ollama backend and indexer to connected clients
- Enables real-time visibility into indexing operations directly in browser DevTools

This helps debug indexing issues by showing exactly what's happening on the server side in the browser console.

## Test plan
- [ ] Start MCP server and open dashboard
- [ ] Open browser DevTools console
- [ ] Trigger re-indexing and verify server logs appear with purple `[server]` prefix
- [ ] Verify Ollama batch progress messages are streamed in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)