### PR TITLE
feat: show Ollama batch progress in dashboard

### DIFF
--- a/src/dashboard/events.ts
+++ b/src/dashboard/events.ts
@@ -200,6 +200,15 @@ export function broadcastLog(level: 'info' | 'warn' | 'error', message: string):
 }
 
 /**
+ * Update the progress message displayed in the dashboard.
+ * This updates just the message text without changing the progress numbers.
+ * Useful for showing sub-progress (e.g., Ollama batch progress).
+ */
+export function updateProgressMessage(message: string): void {
+  dashboardState.updateProgressMessage(message);
+}
+
+/**
  * Singleton instance of the SSE manager
  */
 export const sseManager = new SSEManager();

--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -263,6 +263,17 @@ export class DashboardStateManager extends EventEmitter {
   }
 
   /**
+   * Update just the message portion of the current progress.
+   * Useful for sub-progress updates (e.g., Ollama batch progress).
+   */
+  updateProgressMessage(message: string): void {
+    if (this.lastProgress) {
+      this.lastProgress = { ...this.lastProgress, message };
+      this.emit('progress', this.lastProgress);
+    }
+  }
+
+  /**
    * Called when indexing completes
    */
   onIndexingComplete(result: { filesIndexed: number; chunksCreated: number }): void {


### PR DESCRIPTION
## Summary
- Add `updateProgressMessage` function to update dashboard progress text without changing numbers
- Show "Embedding group X/Y" in progress bar during batch processing
- Add per-batch logging to diagnose hangs - each batch logs start/complete times

This helps diagnose where the indexing process hangs for large codebases.

## Test plan
- [ ] Trigger re-indexing and verify progress text updates
- [ ] Check browser console for individual batch start/complete messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)