### PR TITLE
fix: reduce Ollama concurrency to prevent hangs

### DIFF
--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -7,10 +7,10 @@ import { broadcastLog, updateProgressMessage } from '../dashboard/events.js';
 const DEFAULT_BATCH_SIZE = 50;
 
 /** Default concurrency for Ollama (parallel batch requests) */
-const DEFAULT_CONCURRENCY = 20;
+const DEFAULT_CONCURRENCY = 2;
 
-/** Default timeout for embedding requests (5 minutes per batch) */
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+/** Default timeout for embedding requests (2 minutes per batch) */
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 1000;
 
 /** Default Ollama model optimized for code search */
 export const DEFAULT_OLLAMA_MODEL = 'qwen3-embedding:0.6b';


### PR DESCRIPTION
## Summary
Ollama processes embedding requests sequentially (one model inference at a time), so high concurrency just creates a queue that can overwhelm the server.

Changes:
- Reduce default concurrency from 20 to 2
- Reduce timeout from 5 minutes to 2 minutes

This should prevent hangs when indexing large codebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)