### PR TITLE
fix: sequential Ollama processing and release to alpha tag

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,7 @@
 {
-  "branches": ["main"],
+  "branches": [
+    { "name": "main", "channel": "alpha" }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary

### Ollama fixes:
- Reduce concurrency to 1 (sequential) since Ollama processes one request at a time anyway
- Add timeout logging so we can see when batches time out
- Add error logging for failed batches
- Show all batch statuses in progress text

### Release config:
- Configure semantic-release to publish to `alpha` npm tag instead of `latest`
- This keeps 1.17.1 as the stable `latest` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)