### PR TITLE
fix: display batch statuses on separate lines

### DIFF
--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -115,12 +115,11 @@ export class OllamaBackend implements EmbeddingBackend {
       const batchStatuses = new Map<number, string>();
 
       const updateBatchProgress = () => {
-        const statusParts: string[] = [];
+        const statusLines: string[] = [`Group ${groupNum}/${totalGroups}`];
         for (const [batchNum, status] of batchStatuses) {
-          statusParts.push(`#${batchNum}: ${status}`);
+          statusLines.push(`  Batch ${batchNum}/${batches.length}: ${status}`);
         }
-        const progressMsg = `Group ${groupNum}/${totalGroups} | ${statusParts.join(' | ')}`;
-        updateProgressMessage(progressMsg);
+        updateProgressMessage(statusLines.join('\n'));
       };
 
       const groupStartMsg = `Embedding group ${groupNum}/${totalGroups} (${batchGroup.length} batches)...`;


### PR DESCRIPTION
Show each batch on its own line for better readability.