### PR TITLE
fix: preserve newlines in progress text display

### DIFF
--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -449,6 +449,7 @@ export function getDashboardHTML(): string {
     .progress-text {
       font-size: 12px;
       color: var(--text-secondary);
+      white-space: pre-line;
     }
 
     .patterns-list {


### PR DESCRIPTION
Add CSS white-space: pre-line so batch statuses show on separate lines