### PR TITLE
fix: change default Ollama concurrency to 1

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -718,7 +718,7 @@ export async function getEmbeddingSettings(projectPath: string): Promise<{
     backend: config.embedding?.backend || 'auto',
     hasApiKey: !!(secrets.jinaApiKey || process.env.JINA_API_KEY),
     ollamaUrl: process.env.OLLAMA_URL || 'http://localhost:11434',
-    ollamaConcurrency: config.embedding?.ollamaConcurrency || 100,
+    ollamaConcurrency: config.embedding?.ollamaConcurrency || 1,
     batchSize: config.indexing?.batchSize || DEFAULT_INDEXING.batchSize,
   };
 }

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -1089,7 +1089,7 @@ export function getDashboardHTML(): string {
     const saveStatus = document.getElementById('saveStatus');
 
     // Track saved settings to detect changes
-    let savedSettings = { backend: 'auto', ollamaConcurrency: '200', batchSize: '200' };
+    let savedSettings = { backend: 'auto', ollamaConcurrency: '1', batchSize: '200' };
 
     // Check if current form values differ from saved settings
     function hasSettingsChanged() {
@@ -1129,7 +1129,7 @@ export function getDashboardHTML(): string {
         if (response.ok) {
           const settings = await response.json();
           const backend = settings.backend || 'auto';
-          const concurrency = String(settings.ollamaConcurrency || 200);
+          const concurrency = String(settings.ollamaConcurrency || 1);
           const batchSize = String(settings.batchSize || 200);
 
           // Update saved settings


### PR DESCRIPTION
The config and dashboard UI were defaulting to 100-200 concurrency,
overriding the Ollama backend's DEFAULT_CONCURRENCY = 1.

This caused 10 batches to run in parallel even when the code default was 1.

**Note:** If you have an existing config with `ollamaConcurrency` set, you'll
need to manually edit your `.lance-context.json` to remove it or set it to 1.