### PR TITLE
fix: remove embedded Jina API key (security)

### DIFF
--- a/src/__tests__/embeddings/jina.test.ts
+++ b/src/__tests__/embeddings/jina.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { JinaBackend, DEFAULT_JINA_API_KEY } from '../../embeddings/jina.js';
+import { JinaBackend } from '../../embeddings/jina.js';
 import { createJinaEmbeddingResponse, createErrorFetch } from '../mocks/fetch.mock.js';
 
 describe('JinaBackend', () => {
@@ -12,16 +12,13 @@ describe('JinaBackend', () => {
   });
 
   describe('constructor', () => {
-    it('should use default community API key when none provided', () => {
-      const backend = new JinaBackend({ backend: 'jina' });
-      expect(backend.name).toBe('jina');
-      expect(backend.isUsingDefaultKey()).toBe(true);
+    it('should throw if API key is not provided', () => {
+      expect(() => new JinaBackend({ backend: 'jina' })).toThrow('Jina API key is required');
     });
 
-    it('should accept custom API key in config', () => {
-      const backend = new JinaBackend({ backend: 'jina', apiKey: 'custom-key' });
+    it('should accept API key in config', () => {
+      const backend = new JinaBackend({ backend: 'jina', apiKey: 'test-key' });
       expect(backend.name).toBe('jina');
-      expect(backend.isUsingDefaultKey()).toBe(false);
     });
 
     it('should use default model jina-embeddings-v3', () => {
@@ -36,11 +33,6 @@ describe('JinaBackend', () => {
         model: 'custom-model',
       });
       expect(backend.name).toBe('jina');
-    });
-
-    it('should export the default API key constant', () => {
-      expect(DEFAULT_JINA_API_KEY).toBeDefined();
-      expect(typeof DEFAULT_JINA_API_KEY).toBe('string');
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -715,7 +715,7 @@ export async function getEmbeddingSettings(projectPath: string): Promise<{
   const secrets = await loadSecrets(projectPath);
 
   return {
-    backend: config.embedding?.backend || 'jina',
+    backend: config.embedding?.backend || 'ollama',
     hasApiKey: !!(secrets.jinaApiKey || process.env.JINA_API_KEY),
     ollamaUrl: process.env.OLLAMA_URL || 'http://localhost:11434',
     ollamaConcurrency: config.embedding?.ollamaConcurrency || 1,

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -855,8 +855,8 @@ export function getDashboardHTML(): string {
           <div class="form-group">
             <label for="backendSelect">Select Backend</label>
             <select id="backendSelect" class="form-select">
-              <option value="jina" selected>Jina AI (default - no setup required)</option>
-              <option value="ollama">Ollama (local - requires install)</option>
+              <option value="ollama" selected>Ollama (local)</option>
+              <option value="jina">Jina AI (cloud - requires API key)</option>
             </select>
           </div>
           <div class="form-group" id="ollamaSettingsGroup">
@@ -1097,7 +1097,7 @@ export function getDashboardHTML(): string {
     const saveStatus = document.getElementById('saveStatus');
 
     // Track saved settings to detect changes
-    let savedSettings = { backend: 'jina', ollamaConcurrency: '1', batchSize: '256' };
+    let savedSettings = { backend: 'ollama', ollamaConcurrency: '1', batchSize: '256' };
 
     // Check if current form values differ from saved settings
     function hasSettingsChanged() {
@@ -1136,7 +1136,7 @@ export function getDashboardHTML(): string {
         const response = await fetch('/api/settings/embedding');
         if (response.ok) {
           const settings = await response.json();
-          const backend = settings.backend || 'jina';
+          const backend = settings.backend || 'ollama';
           const concurrency = String(settings.ollamaConcurrency || 1);
           const batchSize = String(settings.batchSize || 256);
 
@@ -1151,15 +1151,17 @@ export function getDashboardHTML(): string {
           updateSaveButtonVisibility();
 
           // Update status badge
-          if (settings.backend === 'ollama') {
+          if (settings.backend === 'jina') {
+            if (settings.hasApiKey) {
+              embeddingStatus.textContent = 'API Key Set';
+              embeddingStatus.className = 'badge success';
+            } else {
+              embeddingStatus.textContent = 'API Key Required';
+              embeddingStatus.className = 'badge warning';
+            }
+          } else {
             embeddingStatus.textContent = 'Local';
             embeddingStatus.className = 'badge';
-          } else if (settings.hasApiKey) {
-            embeddingStatus.textContent = 'Custom Key';
-            embeddingStatus.className = 'badge success';
-          } else {
-            embeddingStatus.textContent = 'Ready';
-            embeddingStatus.className = 'badge success';
           }
         }
       } catch (error) {

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -5,29 +5,26 @@ import { JinaBackend } from './jina.js';
 export * from './types.js';
 export { chunkArray } from './types.js';
 export { OllamaBackend, DEFAULT_OLLAMA_MODEL } from './ollama.js';
-export { JinaBackend, DEFAULT_JINA_API_KEY } from './jina.js';
+export { JinaBackend } from './jina.js';
 export { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 
 /**
  * Create an embedding backend based on configuration and available credentials.
  *
  * Tries backends in priority order:
- * 1. Jina (works out of the box with built-in community API key)
- * 2. Ollama (local alternative, requires Ollama to be installed)
+ * 1. Jina (if JINA_API_KEY environment variable or config.apiKey is set)
+ * 2. Ollama (local fallback, requires Ollama to be running)
  *
  * @param config - Optional configuration to customize the backend
  * @returns A promise resolving to an initialized embedding backend
- * @throws Error if no backend is available
+ * @throws Error if no backend is available (no API keys and Ollama not running)
  *
  * @example
  * ```typescript
- * // Use automatic backend selection (defaults to Jina)
+ * // Use automatic backend selection
  * const backend = await createEmbeddingBackend();
  *
- * // Use your own Jina API key
- * const backend = await createEmbeddingBackend({ apiKey: 'your-key' });
- *
- * // Force Ollama backend
+ * // Force a specific backend
  * const backend = await createEmbeddingBackend({ backend: 'ollama' });
  * ```
  */
@@ -43,11 +40,14 @@ export async function createEmbeddingBackend(
   // If explicit backend is specified, use only that backend
   if (config?.backend && config.backend !== 'local') {
     if (config.backend === 'jina') {
-      // Jina works with or without user-provided key (has built-in default)
+      if (!jinaKey) {
+        throw new Error(
+          'Jina backend requested but no API key available. Set JINA_API_KEY or provide apiKey in config.'
+        );
+      }
       const backend = new JinaBackend({ backend: 'jina', apiKey: jinaKey, ...config });
       await backend.initialize();
-      const keyType = jinaKey ? 'custom key' : 'community key';
-      console.error(`[lance-context] Using jina embedding backend (${keyType})`);
+      console.error(`[lance-context] Using jina embedding backend (explicitly configured)`);
       return backend;
     } else if (config.backend === 'ollama') {
       const backend = new OllamaBackend({
@@ -64,40 +64,36 @@ export async function createEmbeddingBackend(
   }
 
   // Auto-select: try backends in priority order
-  const backends: Array<{ create: () => EmbeddingBackend; name: string }> = [];
+  const backends: Array<() => EmbeddingBackend> = [];
 
-  // Priority 1: Jina (always available - has built-in key)
-  backends.push({
-    create: () => new JinaBackend({ backend: 'jina', apiKey: jinaKey, ...config }),
-    name: jinaKey ? 'jina (custom key)' : 'jina (community key)',
-  });
+  // Priority 1: Jina (if API key available)
+  if (jinaKey) {
+    backends.push(() => new JinaBackend({ backend: 'jina', apiKey: jinaKey, ...config }));
+  }
 
-  // Priority 2: Ollama (local alternative)
-  backends.push({
-    create: () =>
+  // Priority 2: Ollama (local fallback)
+  backends.push(
+    () =>
       new OllamaBackend({
         backend: 'ollama',
         baseUrl: ollamaUrl,
         model: ollamaModel,
         batchSize: ollamaBatchSize,
         concurrency: ollamaConcurrency,
-      }),
-    name: 'ollama',
-  });
+      })
+  );
 
   // Try each backend until one works
-  for (const { create, name } of backends) {
+  for (const createBackend of backends) {
     try {
-      const backend = create();
+      const backend = createBackend();
       await backend.initialize();
-      console.error(`[lance-context] Using ${name} embedding backend`);
+      console.error(`[lance-context] Using ${backend.name} embedding backend`);
       return backend;
     } catch (error) {
-      console.error(`[lance-context] Backend ${name} failed: ${error}`);
+      console.error(`[lance-context] Backend failed: ${error}`);
     }
   }
 
-  throw new Error(
-    'No embedding backend available. Jina API may be unreachable, and Ollama is not running.'
-  );
+  throw new Error('No embedding backend available. Set JINA_API_KEY or install Ollama.');
 }

--- a/src/embeddings/jina.ts
+++ b/src/embeddings/jina.ts
@@ -7,13 +7,6 @@ import { RateLimiter } from './rate-limiter.js';
 const DEFAULT_BATCH_SIZE = 100;
 
 /**
- * Default Jina API key for lance-context demo/community use.
- * This key has spend limits configured in Jina's dashboard.
- * Users can override with their own key via JINA_API_KEY env var or dashboard settings.
- */
-const DEFAULT_JINA_API_KEY = 'jina_0adabc94b5f446b780b98bef76347d37YdXxtgUn7Qd14baAOXT3CfyU2kQo';
-
-/**
  * Jina AI embedding backend
  * Uses Jina's API for high-quality embeddings
  * Includes client-side rate limiting to prevent API throttling
@@ -26,12 +19,15 @@ export class JinaBackend implements EmbeddingBackend {
   private dimensions = 1024; // jina-embeddings-v3 default
   private rateLimiter: RateLimiter;
   private batchSize: number;
-  private usingDefaultKey: boolean;
 
   constructor(config: EmbeddingConfig) {
     this.model = config.model || 'jina-embeddings-v3';
-    this.apiKey = config.apiKey || DEFAULT_JINA_API_KEY;
-    this.usingDefaultKey = !config.apiKey;
+    if (!config.apiKey) {
+      throw new Error(
+        'Jina API key is required. Get a free key at https://jina.ai/embeddings/ and set JINA_API_KEY environment variable.'
+      );
+    }
+    this.apiKey = config.apiKey;
     this.batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
 
     // Initialize rate limiter with configurable or default values
@@ -130,13 +126,4 @@ export class JinaBackend implements EmbeddingBackend {
   getModel(): string {
     return this.model;
   }
-
-  /**
-   * Returns true if using the built-in community API key
-   */
-  isUsingDefaultKey(): boolean {
-    return this.usingDefaultKey;
-  }
 }
-
-export { DEFAULT_JINA_API_KEY };


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Removes the embedded Jina API key that was accidentally committed to the repository.

## Changes

- Removed `DEFAULT_JINA_API_KEY` constant from jina.ts
- Jina backend now requires `JINA_API_KEY` environment variable (throws error if not set)
- Ollama is the default backend again
- Updated dashboard UI to show appropriate status

## Important

The previously committed API key should be rotated immediately in the Jina dashboard as it remains in the git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)