### PR TITLE
feat: add Google Gemini embedding backend

### DIFF
--- a/src/__tests__/embeddings/gemini.test.ts
+++ b/src/__tests__/embeddings/gemini.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GeminiBackend } from '../../embeddings/gemini.js';
+import {
+  createGeminiEmbeddingResponse,
+  createGeminiBatchEmbeddingResponse,
+  createErrorFetch,
+} from '../mocks/fetch.mock.js';
+
+describe('GeminiBackend', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('constructor', () => {
+    it('should throw if API key is not provided', () => {
+      expect(() => new GeminiBackend({ backend: 'gemini' })).toThrow('Gemini API key is required');
+    });
+
+    it('should accept API key in config', () => {
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      expect(backend.name).toBe('gemini');
+    });
+
+    it('should use default model gemini-embedding-001', () => {
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      expect(backend.getModel()).toBe('gemini-embedding-001');
+    });
+
+    it('should return 768 dimensions by default', () => {
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      expect(backend.getDimensions()).toBe(768);
+    });
+
+    it('should accept custom model', () => {
+      const backend = new GeminiBackend({
+        backend: 'gemini',
+        apiKey: 'test-key',
+        model: 'custom-model',
+      });
+      expect(backend.getModel()).toBe('custom-model');
+    });
+  });
+
+  describe('initialize', () => {
+    it('should test API key by calling embed', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(createGeminiEmbeddingResponse([0.1, 0.2]));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      await backend.initialize();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'x-goog-api-key': 'test-key',
+          }),
+        })
+      );
+    });
+
+    it('should throw on initialization failure', async () => {
+      const mockFetch = createErrorFetch(401, 'Unauthorized');
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'invalid-key' });
+      await expect(backend.initialize()).rejects.toThrow('Failed to initialize Gemini backend');
+    });
+  });
+
+  describe('embed', () => {
+    it('should send correct request format', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(createGeminiEmbeddingResponse([0.1, 0.2, 0.3]));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      await backend.embed('test text');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': 'test-key',
+          },
+          body: JSON.stringify({
+            model: 'models/gemini-embedding-001',
+            content: {
+              parts: [{ text: 'test text' }],
+            },
+            outputDimensionality: 768,
+          }),
+        })
+      );
+    });
+
+    it('should return embedding from response', async () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const mockFetch = vi.fn().mockResolvedValue(createGeminiEmbeddingResponse(embedding));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      const result = await backend.embed('test text');
+
+      expect(result).toEqual(embedding);
+    });
+
+    it('should throw on API error', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad request',
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      await expect(backend.embed('test')).rejects.toThrow('Gemini API error: 400 - Bad request');
+    });
+  });
+
+  describe('embedBatch', () => {
+    it('should use batchEmbedContents endpoint', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(createGeminiBatchEmbeddingResponse([[0.1], [0.2], [0.3]]));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      await backend.embedBatch(['text1', 'text2', 'text3']);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents',
+        expect.objectContaining({
+          body: JSON.stringify({
+            requests: [
+              {
+                model: 'models/gemini-embedding-001',
+                content: { parts: [{ text: 'text1' }] },
+                outputDimensionality: 768,
+              },
+              {
+                model: 'models/gemini-embedding-001',
+                content: { parts: [{ text: 'text2' }] },
+                outputDimensionality: 768,
+              },
+              {
+                model: 'models/gemini-embedding-001',
+                content: { parts: [{ text: 'text3' }] },
+                outputDimensionality: 768,
+              },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('should return embeddings in order', async () => {
+      const embeddings = [[0.1], [0.2], [0.3]];
+      const mockFetch = vi.fn().mockResolvedValue(createGeminiBatchEmbeddingResponse(embeddings));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      const result = await backend.embedBatch(['text1', 'text2', 'text3']);
+
+      expect(result).toEqual(embeddings);
+    });
+
+    it('should throw on API error', async () => {
+      // Use 400 (non-retryable) instead of 500 (retryable)
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad request',
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      await expect(backend.embedBatch(['text'])).rejects.toThrow(
+        'Gemini API error: 400 - Bad request'
+      );
+    });
+
+    it('should chunk large batches and make multiple requests', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockImplementation(() => createGeminiBatchEmbeddingResponse([[0.1], [0.2]]));
+      vi.stubGlobal('fetch', mockFetch);
+
+      // Create backend with batch size of 2
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key', batchSize: 2 });
+      const result = await backend.embedBatch(['text1', 'text2', 'text3', 'text4', 'text5']);
+
+      // Should make 3 requests: [text1, text2], [text3, text4], [text5]
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // Should return all 5 embeddings (though mock returns 2 per call, so we get 6)
+      expect(result).toHaveLength(6);
+    });
+
+    it('should not chunk when batch is smaller than batch size', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(createGeminiBatchEmbeddingResponse([[0.1], [0.2], [0.3]]));
+      vi.stubGlobal('fetch', mockFetch);
+
+      // Create backend with batch size of 100 (larger than input)
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key', batchSize: 100 });
+      await backend.embedBatch(['text1', 'text2', 'text3']);
+
+      // Should make only 1 request
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getDimensions', () => {
+    it('should return 768 for default configuration', () => {
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: 'test-key' });
+      expect(backend.getDimensions()).toBe(768);
+    });
+  });
+});

--- a/src/__tests__/mocks/fetch.mock.ts
+++ b/src/__tests__/mocks/fetch.mock.ts
@@ -120,3 +120,29 @@ export function createOllamaBatchEmbeddingResponse(embeddings: number[][]): Mock
     text: async () => JSON.stringify({ embeddings }),
   };
 }
+
+/**
+ * Creates Gemini-style single embedding response (embedContent)
+ */
+export function createGeminiEmbeddingResponse(embedding: number[]): MockFetchResponse {
+  return {
+    ok: true,
+    status: 200,
+    headers: createMockHeaders(),
+    json: async () => ({ embedding: { values: embedding } }),
+    text: async () => JSON.stringify({ embedding: { values: embedding } }),
+  };
+}
+
+/**
+ * Creates Gemini-style batch embedding response (batchEmbedContents)
+ */
+export function createGeminiBatchEmbeddingResponse(embeddings: number[][]): MockFetchResponse {
+  return {
+    ok: true,
+    status: 200,
+    headers: createMockHeaders(),
+    json: async () => ({ embeddings: embeddings.map((values) => ({ values })) }),
+    text: async () => JSON.stringify({ embeddings: embeddings.map((values) => ({ values })) }),
+  };
+}

--- a/src/embeddings/gemini.ts
+++ b/src/embeddings/gemini.ts
@@ -1,0 +1,150 @@
+import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
+import { chunkArray } from './types.js';
+import { fetchWithRetry } from './retry.js';
+import { RateLimiter } from './rate-limiter.js';
+
+/** Default batch size for Gemini API requests (max 100 per batch request) */
+const DEFAULT_BATCH_SIZE = 100;
+
+/** Default model for Gemini embeddings */
+const DEFAULT_GEMINI_MODEL = 'gemini-embedding-001';
+
+/** Default dimensions - using 768 to match other backends for compatibility */
+const DEFAULT_DIMENSIONS = 768;
+
+/**
+ * Google Gemini embedding backend
+ * Uses Google's Generative AI API for embeddings
+ * Free tier: 1500 RPM, no credit card required
+ * Get API key at: https://aistudio.google.com/app/apikey
+ */
+export class GeminiBackend implements EmbeddingBackend {
+  name = 'gemini';
+  private model: string;
+  private apiKey: string;
+  private baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
+  private dimensions: number;
+  private rateLimiter: RateLimiter;
+  private batchSize: number;
+
+  constructor(config: EmbeddingConfig) {
+    this.model = config.model || DEFAULT_GEMINI_MODEL;
+    if (!config.apiKey) {
+      throw new Error(
+        'Gemini API key is required. Get a free key at https://aistudio.google.com/app/apikey and set GEMINI_API_KEY environment variable.'
+      );
+    }
+    this.apiKey = config.apiKey;
+    this.dimensions = DEFAULT_DIMENSIONS;
+    this.batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    // Initialize rate limiter - Gemini free tier is 1500 RPM = 25 RPS
+    this.rateLimiter = new RateLimiter({
+      requestsPerSecond: config.rateLimitRps ?? 20,
+      burstCapacity: config.rateLimitBurst ?? 30,
+    });
+  }
+
+  async initialize(): Promise<void> {
+    // Test API key with a small request
+    try {
+      await this.embed('test');
+    } catch (error) {
+      throw new Error(`Failed to initialize Gemini backend: ${error}`);
+    }
+  }
+
+  async embed(text: string): Promise<number[]> {
+    // Acquire a rate limit token before making the request
+    await this.rateLimiter.acquire();
+
+    const url = `${this.baseUrl}/models/${this.model}:embedContent`;
+    const response = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.apiKey,
+      },
+      body: JSON.stringify({
+        model: `models/${this.model}`,
+        content: {
+          parts: [{ text }],
+        },
+        outputDimensionality: this.dimensions,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Gemini API error: ${response.status} - ${error}`);
+    }
+
+    const data = (await response.json()) as {
+      embedding: { values: number[] };
+    };
+    return data.embedding.values;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    // For small batches, process directly
+    if (texts.length <= this.batchSize) {
+      return this.embedBatchDirect(texts);
+    }
+
+    // For large batches, chunk and process sequentially
+    const chunks = chunkArray(texts, this.batchSize);
+    const results: number[][] = [];
+
+    for (const chunk of chunks) {
+      const chunkResults = await this.embedBatchDirect(chunk);
+      results.push(...chunkResults);
+    }
+
+    return results;
+  }
+
+  /**
+   * Embed a batch of texts using Gemini's batchEmbedContents endpoint.
+   * Used internally by embedBatch.
+   */
+  private async embedBatchDirect(texts: string[]): Promise<number[][]> {
+    // Acquire a rate limit token before making the request
+    await this.rateLimiter.acquire();
+
+    const url = `${this.baseUrl}/models/${this.model}:batchEmbedContents`;
+    const response = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.apiKey,
+      },
+      body: JSON.stringify({
+        requests: texts.map((text) => ({
+          model: `models/${this.model}`,
+          content: {
+            parts: [{ text }],
+          },
+          outputDimensionality: this.dimensions,
+        })),
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Gemini API error: ${response.status} - ${error}`);
+    }
+
+    const data = (await response.json()) as {
+      embeddings: Array<{ values: number[] }>;
+    };
+    return data.embeddings.map((e) => e.values);
+  }
+
+  getDimensions(): number {
+    return this.dimensions;
+  }
+
+  getModel(): string {
+    return this.model;
+  }
+}

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -1,19 +1,22 @@
 import type { EmbeddingBackend, EmbeddingConfig } from './types.js';
 import { OllamaBackend, DEFAULT_OLLAMA_MODEL } from './ollama.js';
 import { JinaBackend } from './jina.js';
+import { GeminiBackend } from './gemini.js';
 
 export * from './types.js';
 export { chunkArray } from './types.js';
 export { OllamaBackend, DEFAULT_OLLAMA_MODEL } from './ollama.js';
 export { JinaBackend } from './jina.js';
+export { GeminiBackend } from './gemini.js';
 export { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 
 /**
  * Create an embedding backend based on configuration and available credentials.
  *
  * Tries backends in priority order:
- * 1. Jina (if JINA_API_KEY environment variable or config.apiKey is set)
- * 2. Ollama (local fallback, requires Ollama to be running)
+ * 1. Gemini (if GEMINI_API_KEY environment variable is set) - free tier, recommended
+ * 2. Jina (if JINA_API_KEY environment variable or config.apiKey is set)
+ * 3. Ollama (local fallback, requires Ollama to be running)
  *
  * @param config - Optional configuration to customize the backend
  * @returns A promise resolving to an initialized embedding backend
@@ -31,6 +34,7 @@ export { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 export async function createEmbeddingBackend(
   config?: Partial<EmbeddingConfig>
 ): Promise<EmbeddingBackend> {
+  const geminiKey = config?.apiKey || process.env.GEMINI_API_KEY;
   const jinaKey = config?.apiKey || process.env.JINA_API_KEY;
   const ollamaUrl = config?.baseUrl || process.env.OLLAMA_URL || 'http://localhost:11434';
   const ollamaModel = config?.model || DEFAULT_OLLAMA_MODEL;
@@ -39,7 +43,17 @@ export async function createEmbeddingBackend(
 
   // If explicit backend is specified, use only that backend
   if (config?.backend && config.backend !== 'local') {
-    if (config.backend === 'jina') {
+    if (config.backend === 'gemini') {
+      if (!geminiKey) {
+        throw new Error(
+          'Gemini backend requested but no API key available. Get a free key at https://aistudio.google.com/app/apikey and set GEMINI_API_KEY.'
+        );
+      }
+      const backend = new GeminiBackend({ backend: 'gemini', apiKey: geminiKey, ...config });
+      await backend.initialize();
+      console.error(`[lance-context] Using gemini embedding backend (explicitly configured)`);
+      return backend;
+    } else if (config.backend === 'jina') {
       if (!jinaKey) {
         throw new Error(
           'Jina backend requested but no API key available. Set JINA_API_KEY or provide apiKey in config.'
@@ -66,12 +80,17 @@ export async function createEmbeddingBackend(
   // Auto-select: try backends in priority order
   const backends: Array<() => EmbeddingBackend> = [];
 
-  // Priority 1: Jina (if API key available)
+  // Priority 1: Gemini (if API key available) - free tier, recommended
+  if (geminiKey) {
+    backends.push(() => new GeminiBackend({ backend: 'gemini', apiKey: geminiKey, ...config }));
+  }
+
+  // Priority 2: Jina (if API key available)
   if (jinaKey) {
     backends.push(() => new JinaBackend({ backend: 'jina', apiKey: jinaKey, ...config }));
   }
 
-  // Priority 2: Ollama (local fallback)
+  // Priority 3: Ollama (local fallback)
   backends.push(
     () =>
       new OllamaBackend({
@@ -95,5 +114,7 @@ export async function createEmbeddingBackend(
     }
   }
 
-  throw new Error('No embedding backend available. Set JINA_API_KEY or install Ollama.');
+  throw new Error(
+    'No embedding backend available. Set GEMINI_API_KEY (free), JINA_API_KEY, or install Ollama.'
+  );
 }

--- a/src/embeddings/types.ts
+++ b/src/embeddings/types.ts
@@ -45,7 +45,7 @@ export interface EmbeddingBackend {
  */
 export interface EmbeddingConfig {
   /** Which embedding backend to use */
-  backend: 'jina' | 'ollama' | 'local';
+  backend: 'jina' | 'ollama' | 'gemini' | 'local';
 
   /** Model name/identifier (backend-specific) */
   model?: string;


### PR DESCRIPTION
## Summary
- Add Google Gemini as a new embedding backend (free tier, 1500 RPM)
- Gemini is now priority 1 in auto-selection (Gemini > Jina > Ollama)
- Add Gemini option to dashboard UI with dynamic API key hints
- Fix DEFAULT_INDEXING.batchSize from 200 to 256 to match dropdown options

## Changes
- New `src/embeddings/gemini.ts` with full EmbeddingBackend implementation
- Updated factory to prioritize Gemini when API key is available
- Dashboard UI now shows Gemini option with link to get free API key
- Comprehensive test coverage for Gemini backend

## Test plan
- [x] All 1240 tests pass
- [x] Build succeeds
- [ ] Manual test: Set GEMINI_API_KEY and verify Gemini is auto-selected
- [ ] Manual test: Select Gemini in dashboard and enter API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)