### PR TITLE
fix: allow gemini in backend validation

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -189,8 +189,8 @@ async function handleSaveEmbeddingSettings(
   try {
     const body = (await parseJsonBody(req)) as EmbeddingSettings;
 
-    if (!body.backend || !['jina', 'ollama'].includes(body.backend)) {
-      sendJSON(res, { error: 'Invalid backend. Must be "jina" or "ollama".' }, 400);
+    if (!body.backend || !['jina', 'ollama', 'gemini'].includes(body.backend)) {
+      sendJSON(res, { error: 'Invalid backend. Must be "jina", "ollama", or "gemini".' }, 400);
       return;
     }
 


### PR DESCRIPTION
## Summary
The save endpoint was rejecting 'gemini' as an invalid backend.

## Changes
- Added 'gemini' to the valid backends list in routes.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)