### PR TITLE
feat: make Gemini the default embedding backend

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -718,7 +718,7 @@ export async function getEmbeddingSettings(projectPath: string): Promise<{
 }> {
   const config = await loadConfig(projectPath);
   const secrets = await loadSecrets(projectPath);
-  const backend = config.embedding?.backend || 'ollama';
+  const backend = config.embedding?.backend || 'gemini';
 
   // Check for API key based on backend
   let hasApiKey = false;

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -855,8 +855,8 @@ export function getDashboardHTML(): string {
           <div class="form-group">
             <label for="backendSelect">Select Backend</label>
             <select id="backendSelect" class="form-select">
-              <option value="ollama" selected>Ollama (local)</option>
-              <option value="gemini">Google Gemini (free - requires API key)</option>
+              <option value="ollama">Ollama (local)</option>
+              <option value="gemini" selected>Google Gemini (free - requires API key)</option>
               <option value="jina">Jina AI (paid - requires API key)</option>
             </select>
           </div>
@@ -1098,7 +1098,7 @@ export function getDashboardHTML(): string {
     const saveStatus = document.getElementById('saveStatus');
 
     // Track saved settings to detect changes
-    let savedSettings = { backend: 'ollama', ollamaConcurrency: '1', batchSize: '256' };
+    let savedSettings = { backend: 'gemini', ollamaConcurrency: '1', batchSize: '256' };
 
     // Check if current form values differ from saved settings
     function hasSettingsChanged() {
@@ -1166,7 +1166,7 @@ export function getDashboardHTML(): string {
         const response = await fetch('/api/settings/embedding');
         if (response.ok) {
           const settings = await response.json();
-          const backend = settings.backend || 'ollama';
+          const backend = settings.backend || 'gemini';
           const concurrency = String(settings.ollamaConcurrency || 1);
           const batchSize = String(settings.batchSize || 256);
 

--- a/src/embeddings/types.ts
+++ b/src/embeddings/types.ts
@@ -93,10 +93,11 @@ export function chunkArray<T>(array: T[], size: number): T[][] {
 }
 
 /**
- * Default embedding configuration using local Ollama with nomic-embed-text model.
+ * Default embedding configuration using Google Gemini.
+ * Gemini offers a free tier with 1500 RPM.
+ * Get API key at: https://aistudio.google.com/app/apikey
  */
 export const DEFAULT_CONFIG: EmbeddingConfig = {
-  backend: 'ollama',
-  model: 'nomic-embed-text',
-  baseUrl: 'http://localhost:11434',
+  backend: 'gemini',
+  model: 'gemini-embedding-001',
 };


### PR DESCRIPTION
## Summary
Changes the default embedding backend from Ollama to Gemini.

## Changes
- `config.ts`: Default backend fallback changed to 'gemini'
- `ui.ts`: Dashboard dropdown now selects Gemini by default
- `types.ts`: DEFAULT_CONFIG now uses Gemini

Gemini offers a free tier (1500 RPM) and is now the recommended backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)