### PR TITLE
fix: show restart message after saving embedding settings

### DIFF
--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -1234,7 +1234,8 @@ export function getDashboardHTML(): string {
           saveStatus.textContent = 'Saved! Restart server to apply.';
           saveStatus.className = 'save-status success';
           apiKeyInput.value = ''; // Clear the input
-          loadEmbeddingSettings(); // Reload to update status
+          // Delay reload so user sees the success message (reload clears status)
+          setTimeout(loadEmbeddingSettings, 3000);
         } else {
           saveStatus.textContent = result.error || 'Failed to save';
           saveStatus.className = 'save-status error';


### PR DESCRIPTION
## Summary
- Fix bug where "Saved! Restart server to apply." message was not visible
- The message was being cleared immediately by `loadEmbeddingSettings()` calling `updateSaveButtonVisibility()` which clears the status text
- Add 3-second delay before reloading settings so users can see the restart notification

## Test plan
- [ ] Save embedding settings in dashboard
- [ ] Verify "Saved! Restart server to apply." message appears for 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)