### PR TITLE
fix: add 60-second timeout to embedding API requests

### DIFF
--- a/src/__tests__/embeddings/retry.test.ts
+++ b/src/__tests__/embeddings/retry.test.ts
@@ -37,7 +37,7 @@ describe('fetchWithRetry', () => {
 
       await fetchWithRetry('https://api.test.com', options);
 
-      expect(fetch).toHaveBeenCalledWith('https://api.test.com', options);
+      expect(fetch).toHaveBeenCalledWith('https://api.test.com', expect.objectContaining(options));
     });
   });
 


### PR DESCRIPTION
## Summary
- Add 60-second timeout to all embedding API requests to prevent hangs
- Previously, fetch requests could hang indefinitely if the API was slow/unresponsive
- This caused indexing to appear stuck with no progress updates

## Changes
- Add `timeoutMs` option to `fetchWithRetry` (default: 60 seconds)
- Use `AbortController` to enforce request timeout  
- Treat timeout errors as retryable (will retry with exponential backoff)
- Clear error messages: "Request timeout after 60000ms"

## Test plan
- [x] Unit tests pass
- [ ] Test indexing with slow network conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)