### PR TITLE
feat: add server log panel to dashboard

### DIFF
--- a/src/embeddings/gemini.ts
+++ b/src/embeddings/gemini.ts
@@ -143,9 +143,15 @@ export class GeminiBackend implements EmbeddingBackend {
    */
   private async embedBatchDirect(texts: string[]): Promise<number[][]> {
     // Acquire a rate limit token before making the request
-    console.error(`[lance-context] Gemini: acquiring rate limit token...`);
+    const acquireMsg = 'Gemini: acquiring rate limit token...';
+    console.error(`[lance-context] ${acquireMsg}`);
+    broadcastLog('info', acquireMsg);
+
     await this.rateLimiter.acquire();
-    console.error(`[lance-context] Gemini: rate limit token acquired`);
+
+    const acquiredMsg = 'Gemini: rate limit token acquired';
+    console.error(`[lance-context] ${acquiredMsg}`);
+    broadcastLog('info', acquiredMsg);
 
     const url = `${this.baseUrl}/models/${this.model}:batchEmbedContents`;
     const requestBody = JSON.stringify({
@@ -159,9 +165,9 @@ export class GeminiBackend implements EmbeddingBackend {
     });
 
     const payloadSizeKb = (requestBody.length / 1024).toFixed(1);
-    console.error(
-      `[lance-context] Gemini: sending batch request (${texts.length} texts, ${payloadSizeKb} KB payload)...`
-    );
+    const sendingMsg = `Gemini: sending batch request (${texts.length} texts, ${payloadSizeKb} KB payload)...`;
+    console.error(`[lance-context] ${sendingMsg}`);
+    broadcastLog('info', sendingMsg);
 
     const fetchStart = Date.now();
     const response = await fetchWithRetry(url, {
@@ -174,9 +180,9 @@ export class GeminiBackend implements EmbeddingBackend {
     });
 
     const fetchTime = ((Date.now() - fetchStart) / 1000).toFixed(1);
-    console.error(
-      `[lance-context] Gemini: received response in ${fetchTime}s (status: ${response.status})`
-    );
+    const responseMsg = `Gemini: received response in ${fetchTime}s (status: ${response.status})`;
+    console.error(`[lance-context] ${responseMsg}`);
+    broadcastLog('info', responseMsg);
 
     if (!response.ok) {
       const error = await response.text();


### PR DESCRIPTION
## Summary
Add a collapsible log panel to the dashboard that displays server logs in real-time via SSE. This helps diagnose issues when running as an MCP server where terminal output isn't accessible (e.g., Claude Desktop).

## Features
- Real-time log display via SSE events
- Collapsible panel (click header to toggle)
- Clear button to reset logs
- Auto-scrolls to latest entries
- Keeps max 500 entries to prevent memory issues
- Color-coded log levels (info, warn, error)

## Test plan
- [ ] Start indexing and verify logs appear in panel
- [ ] Test collapse/expand functionality
- [ ] Test clear button
- [ ] Verify auto-scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)