### PR TITLE
fix: resolve project path and add force option to open_dashboard

### DIFF
--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,0 +1,8 @@
+---
+name: dashboard
+description: Open the lance-context dashboard in the browser
+---
+
+Open the lance-context dashboard using the `mcp__lance-context__open_dashboard` tool with `force: true` to bypass the cooldown.
+
+The tool will return the actual URL where the dashboard is running (port may vary if 24300 is already in use by another instance).


### PR DESCRIPTION
## Summary
- Fix project name displaying "." by resolving PROJECT_PATH to absolute path
- Add `force` parameter to `open_dashboard` tool to bypass 1-hour browser cooldown
- Add `/dashboard` slash command for Claude Code

## Test plan
- [x] Type check passes
- [x] Dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)