### PR TITLE
fix: correctly show Ollama fallback state in dashboard

### DIFF
--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -169,7 +169,16 @@ async function handleGetEmbeddingSettings(
 
   try {
     const settings = await getEmbeddingSettings(projectPath);
-    sendJSON(res, settings);
+
+    // Include running backend and fallback info so UI can show actual state
+    const status = await dashboardState.getStatus();
+    const fallback = dashboardState.getBackendFallback();
+
+    sendJSON(res, {
+      ...settings,
+      runningBackend: status?.embeddingBackend ?? null,
+      fallback,
+    });
   } catch (error) {
     sendJSON(res, { error: String(error) }, 500);
   }

--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -218,6 +218,13 @@ export class DashboardStateManager extends EventEmitter {
   }
 
   /**
+   * Clear backend fallback info (when backend is successfully reinitialized)
+   */
+  clearBackendFallback(): void {
+    this.backendFallback = null;
+  }
+
+  /**
    * Get backend fallback info if a fallback occurred
    */
   getBackendFallback(): BackendFallbackInfo | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,9 +371,11 @@ async function getIndexer(): Promise<CodeIndexer> {
       dashboardState.setConfig(config);
       dashboardState.setProjectPath(PROJECT_PATH);
 
-      // Track backend fallback if it occurred
+      // Track backend fallback if it occurred, or clear if successful
       if (fallback) {
         dashboardState.setBackendFallback(fallback);
+      } else {
+        dashboardState.clearBackendFallback();
       }
 
       return idx;


### PR DESCRIPTION
## Summary
- Settings dropdown now shows actual running backend (Ollama) when fallback occurs instead of configured backend (Gemini)
- Status badge shows "Fallback Active" warning during fallback mode
- Removed misleading "restart needed" badge when fallback is active (restart won't help)
- Fallback state clears when backend successfully reinitializes on config reload

## Test plan
- [ ] Configure Gemini backend without valid API key or with rate limiting
- [ ] Verify dashboard shows Ollama in dropdown with "Fallback Active" badge
- [ ] Verify no "restart needed" badge appears
- [ ] Change settings and save, verify fallback clears if backend works

🤖 Generated with [Claude Code](https://claude.com/claude-code)