### PR TITLE
chore: drop Node 20.x from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Simplifies CI by testing only on Node 22.x (latest LTS)
- Node 20.x minimum version still enforced via `engines` field in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)