### PR TITLE
feat: add init_project tool for project setup

### DIFF
--- a/src/__tests__/tools/init-handlers.test.ts
+++ b/src/__tests__/tools/init-handlers.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for init-handlers.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import { handleInitProject } from '../../tools/init-handlers.js';
+
+// Mock fs module
+vi.mock('fs');
+
+describe('handleInitProject', () => {
+  const mockProjectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('CLAUDE.md handling', () => {
+    it('should create new CLAUDE.md when it does not exist', async () => {
+      // Mock: no CLAUDE.md exists, .git exists
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('.git')) return true;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('hooks')) return true;
+        return false;
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('Created CLAUDE.md with glancey instructions');
+    });
+
+    it('should update existing CLAUDE.md without glancey section', async () => {
+      // Mock: CLAUDE.md exists without glancey section
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return true;
+        if (pathStr.includes('.git')) return true;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('hooks')) return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) {
+          return '# Project\n\nSome existing content';
+        }
+        return '';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('Added glancey section to existing CLAUDE.md');
+    });
+
+    it('should skip CLAUDE.md when glancey section already exists', async () => {
+      // Mock: CLAUDE.md exists with glancey section
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return true;
+        if (pathStr.includes('.git')) return true;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('hooks')) return true;
+        if (pathStr.includes('post-commit')) return false;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) {
+          return '# Project\n\n## Glancey\n\nAlready configured';
+        }
+        return '';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('CLAUDE.md already contains glancey instructions');
+    });
+  });
+
+  describe('post-commit hook handling', () => {
+    it('should skip hook when not a git repository', async () => {
+      // Mock: no .git directory
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('.git')) return false;
+        return false;
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('Not a git repository');
+    });
+
+    it('should install hook in .git/hooks when husky is not used', async () => {
+      // Mock: .git exists but no husky
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('post-commit')) return false;
+        if (pathStr.includes('hooks')) return true;
+        if (pathStr.includes('.git')) return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation(() => '');
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('.git/hooks/post-commit');
+    });
+
+    it('should install hook in .husky when husky is present', async () => {
+      // Mock: husky directory exists
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('post-commit')) return false;
+        if (pathStr.includes('.husky')) return true;
+        if (pathStr.includes('.git')) return true;
+        return false;
+      });
+      vi.mocked(fs.statSync).mockImplementation(() => ({ isDirectory: () => true }) as fs.Stats);
+      vi.mocked(fs.readFileSync).mockImplementation(() => '');
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('.husky/post-commit');
+    });
+
+    it('should skip hook when already contains glancey check', async () => {
+      // Mock: hook exists with glancey content
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('.git')) return true;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('hooks')) return true;
+        if (pathStr.includes('post-commit')) return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('post-commit')) {
+          return '#!/bin/sh\n# Existing hook with MCP_COMMIT_MARKER check';
+        }
+        return '';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('Hook already contains glancey check');
+    });
+  });
+
+  describe('response format', () => {
+    it('should include next steps when changes are made', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr.includes('CLAUDE.md')) return false;
+        if (pathStr.includes('.git')) return true;
+        if (pathStr.includes('.husky')) return false;
+        if (pathStr.includes('hooks')) return true;
+        if (pathStr.includes('post-commit')) return false;
+        return false;
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.chmodSync).mockImplementation(() => {});
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+
+      const result = await handleInitProject({ projectPath: mockProjectPath });
+
+      expect(result.content[0].text).toContain('Next Steps');
+      expect(result.content[0].text).toContain('Commit the CLAUDE.md changes');
+    });
+  });
+});

--- a/src/dashboard/state.ts
+++ b/src/dashboard/state.ts
@@ -42,7 +42,9 @@ export type CommandName =
   | 'search_by_concept'
   | 'summarize_codebase'
   // Dashboard tools
-  | 'open_dashboard';
+  | 'open_dashboard'
+  // Project setup tools
+  | 'init_project';
 
 /**
  * Command usage statistics
@@ -105,6 +107,8 @@ const COMMAND_LABELS: Record<CommandName, string> = {
   summarize_codebase: 'Summarize Codebase',
   // Dashboard tools
   open_dashboard: 'Open Dashboard',
+  // Project setup tools
+  init_project: 'Init Project',
 };
 
 /** Maximum number of event listeners to prevent memory leaks */

--- a/src/tools/init-handlers.ts
+++ b/src/tools/init-handlers.ts
@@ -1,0 +1,317 @@
+/**
+ * Handlers for project initialization tools.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ToolResponse } from './types.js';
+
+/**
+ * Template for CLAUDE.md glancey section
+ */
+const GLANCEY_CLAUDE_MD_SECTION = `
+## Glancey - Semantic Code Intelligence
+
+This project uses **glancey** MCP for semantic code search and codebase understanding.
+
+### Critical Rules
+
+- **ALWAYS use \`commit\`** for git commits - never raw \`git commit\`
+- **Use \`search_code\`** before grep/ripgrep when unsure of exact names
+- **Use \`search_similar\`** before writing new code to check for existing patterns
+- **Run \`summarize_codebase\`** at session start if unfamiliar with the project
+
+### Tool Reference
+
+#### Codebase Understanding
+| Tool | When to Use |
+|------|-------------|
+| \`summarize_codebase\` | **First thing** when exploring a new codebase |
+| \`list_concepts\` | Discover semantic groupings (auth, database, API, etc.) |
+| \`search_by_concept\` | Deep-dive into a specific concept area |
+
+#### Semantic Search
+| Tool | When to Use |
+|------|-------------|
+| \`search_code\` | Find code by concept when unsure of exact names |
+| \`search_similar\` | Find duplicate/related patterns for refactoring |
+
+#### Symbol Analysis
+| Tool | When to Use |
+|------|-------------|
+| \`get_symbols_overview\` | Understand a file's structure (classes, functions, etc.) |
+| \`find_symbol\` | Find symbols by name pattern (supports globs) |
+| \`find_referencing_symbols\` | Find all references to a symbol |
+| \`search_for_pattern\` | Regex search across codebase |
+
+#### Symbol Editing
+| Tool | When to Use |
+|------|-------------|
+| \`replace_symbol_body\` | Rewrite a function/class/method |
+| \`insert_before_symbol\` | Add code before a symbol |
+| \`insert_after_symbol\` | Add code after a symbol |
+| \`rename_symbol\` | Rename symbol and update all references |
+
+#### Memory (Persistent Context)
+| Tool | When to Use |
+|------|-------------|
+| \`write_memory\` | Save architectural decisions, patterns, context |
+| \`read_memory\` | Retrieve saved context |
+| \`list_memories\` | See available memory files |
+| \`edit_memory\` | Update existing memory |
+| \`delete_memory\` | Remove outdated memory |
+
+#### Git Operations
+| Tool | When to Use |
+|------|-------------|
+| \`commit\` | **ALWAYS** use instead of raw \`git commit\` |
+
+#### Worktrees (Parallel Development)
+| Tool | When to Use |
+|------|-------------|
+| \`create_worktree\` | Create isolated worktree for parallel work |
+| \`list_worktrees\` | See active worktrees |
+| \`worktree_status\` | Check a worktree's git state |
+| \`remove_worktree\` | Clean up after parallel work |
+
+#### Index Management
+| Tool | When to Use |
+|------|-------------|
+| \`index_codebase\` | Re-index after major file changes |
+| \`get_index_status\` | Check if reindexing is needed |
+| \`clear_index\` | Clear and rebuild index |
+
+### Signs You Should Use Glancey
+
+- You used wildcards or regex to find something
+- Multiple search attempts to find code
+- Pattern-based search returned nothing
+- Searching by concept, not exact identifier
+- Exploring an unfamiliar codebase
+- About to write code that might duplicate existing patterns
+`;
+
+/**
+ * Post-commit hook script content
+ */
+const POST_COMMIT_HOOK = `#!/usr/bin/env sh
+
+# Glancey post-commit hook
+# Warns when commits bypass the glancey commit tool
+
+MARKER_FILE=".git/MCP_COMMIT_MARKER"
+
+if [ -f "$MARKER_FILE" ]; then
+  # Commit was made via MCP tool - clean up marker
+  rm -f "$MARKER_FILE"
+else
+  # Commit bypassed MCP tool - warn the user
+  echo ""
+  echo "⚠️  WARNING: Commit made without using glancey commit tool"
+  echo ""
+  echo "Always use the MCP 'commit' tool instead of raw 'git commit'."
+  echo "The commit tool validates:"
+  echo "  - Feature branch (not main)"
+  echo "  - Message format (≤72 chars, imperative mood)"
+  echo "  - Single responsibility per commit"
+  echo ""
+  echo "Example: mcp__glancey__commit(message: \\"feat: add feature\\")"
+  echo ""
+fi
+`;
+
+/**
+ * Context for init tools.
+ */
+export interface InitToolContext {
+  projectPath: string;
+}
+
+/**
+ * Result of initialization
+ */
+interface InitResult {
+  claudeMdUpdated: boolean;
+  claudeMdCreated: boolean;
+  hookInstalled: boolean;
+  hookSkipped: boolean;
+  hookSkipReason?: string;
+  messages: string[];
+}
+
+/**
+ * Check if a file contains a glancey section
+ */
+function hasGlanceySection(content: string): boolean {
+  return (
+    content.includes('## Glancey') ||
+    content.includes('mcp__glancey__commit') ||
+    content.includes('glancey MCP')
+  );
+}
+
+/**
+ * Update or create CLAUDE.md with glancey instructions
+ */
+function updateClaudeMd(projectPath: string): { created: boolean; updated: boolean } {
+  const claudeMdPath = path.join(projectPath, 'CLAUDE.md');
+
+  if (fs.existsSync(claudeMdPath)) {
+    const content = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    // Check if glancey section already exists
+    if (hasGlanceySection(content)) {
+      return { created: false, updated: false };
+    }
+
+    // Append glancey section
+    const updatedContent = content.trimEnd() + '\n' + GLANCEY_CLAUDE_MD_SECTION;
+    fs.writeFileSync(claudeMdPath, updatedContent);
+    return { created: false, updated: true };
+  } else {
+    // Create new CLAUDE.md
+    const newContent = `# Project Instructions
+${GLANCEY_CLAUDE_MD_SECTION}`;
+    fs.writeFileSync(claudeMdPath, newContent);
+    return { created: true, updated: false };
+  }
+}
+
+/**
+ * Detect if project uses husky
+ */
+function usesHusky(projectPath: string): boolean {
+  const huskyDir = path.join(projectPath, '.husky');
+  return fs.existsSync(huskyDir) && fs.statSync(huskyDir).isDirectory();
+}
+
+/**
+ * Install post-commit hook
+ */
+function installPostCommitHook(projectPath: string): {
+  installed: boolean;
+  skipped: boolean;
+  reason?: string;
+} {
+  const gitDir = path.join(projectPath, '.git');
+
+  // Check if this is a git repo
+  if (!fs.existsSync(gitDir)) {
+    return { installed: false, skipped: true, reason: 'Not a git repository' };
+  }
+
+  // Determine hook location
+  let hookPath: string;
+  if (usesHusky(projectPath)) {
+    hookPath = path.join(projectPath, '.husky', 'post-commit');
+  } else {
+    const hooksDir = path.join(gitDir, 'hooks');
+    if (!fs.existsSync(hooksDir)) {
+      fs.mkdirSync(hooksDir, { recursive: true });
+    }
+    hookPath = path.join(hooksDir, 'post-commit');
+  }
+
+  // Check if hook already exists
+  if (fs.existsSync(hookPath)) {
+    const existingContent = fs.readFileSync(hookPath, 'utf-8');
+
+    // Check if it already has glancey content
+    if (existingContent.includes('MCP_COMMIT_MARKER') || existingContent.includes('glancey')) {
+      return { installed: false, skipped: true, reason: 'Hook already contains glancey check' };
+    }
+
+    // Append to existing hook (without shebang)
+    const hookBody = POST_COMMIT_HOOK.split('\n').slice(1).join('\n');
+    const updatedContent = existingContent.trimEnd() + '\n\n# Glancey commit check\n' + hookBody;
+    fs.writeFileSync(hookPath, updatedContent);
+    fs.chmodSync(hookPath, '755');
+    return { installed: true, skipped: false };
+  }
+
+  // Create new hook
+  fs.writeFileSync(hookPath, POST_COMMIT_HOOK);
+  fs.chmodSync(hookPath, '755');
+  return { installed: true, skipped: false };
+}
+
+/**
+ * Handle init_project tool.
+ */
+export async function handleInitProject(context: InitToolContext): Promise<ToolResponse> {
+  const result: InitResult = {
+    claudeMdUpdated: false,
+    claudeMdCreated: false,
+    hookInstalled: false,
+    hookSkipped: false,
+    messages: [],
+  };
+
+  // Update CLAUDE.md
+  try {
+    const claudeResult = updateClaudeMd(context.projectPath);
+    result.claudeMdCreated = claudeResult.created;
+    result.claudeMdUpdated = claudeResult.updated;
+
+    if (claudeResult.created) {
+      result.messages.push('✓ Created CLAUDE.md with glancey instructions');
+    } else if (claudeResult.updated) {
+      result.messages.push('✓ Added glancey section to existing CLAUDE.md');
+    } else {
+      result.messages.push('• CLAUDE.md already contains glancey instructions');
+    }
+  } catch (error) {
+    result.messages.push(`✗ Failed to update CLAUDE.md: ${error}`);
+  }
+
+  // Install post-commit hook
+  try {
+    const hookResult = installPostCommitHook(context.projectPath);
+    result.hookInstalled = hookResult.installed;
+    result.hookSkipped = hookResult.skipped;
+    result.hookSkipReason = hookResult.reason;
+
+    if (hookResult.installed) {
+      const location = usesHusky(context.projectPath)
+        ? '.husky/post-commit'
+        : '.git/hooks/post-commit';
+      result.messages.push(`✓ Installed post-commit hook at ${location}`);
+    } else if (hookResult.skipped) {
+      result.messages.push(`• Skipped hook installation: ${hookResult.reason}`);
+    }
+  } catch (error) {
+    result.messages.push(`✗ Failed to install hook: ${error}`);
+  }
+
+  // Build response
+  const summary = result.messages.join('\n');
+  const nextSteps: string[] = [];
+
+  if (result.claudeMdCreated || result.claudeMdUpdated) {
+    nextSteps.push('- Review and customize CLAUDE.md as needed');
+    nextSteps.push('- Commit the CLAUDE.md changes');
+  }
+
+  if (result.hookInstalled && !usesHusky(context.projectPath)) {
+    nextSteps.push(
+      '- Note: .git/hooks are not tracked by git - team members need to run init_project too'
+    );
+  }
+
+  const response = `# Glancey Project Initialization
+
+${summary}
+
+${nextSteps.length > 0 ? '## Next Steps\n\n' + nextSteps.join('\n') : ''}
+
+## What was configured
+
+1. **CLAUDE.md** - Added comprehensive instructions for agents to use glancey tools
+2. **Post-commit hook** - Warns when commits bypass the glancey commit tool
+
+Agents will now see glancey usage instructions when working in this project.`;
+
+  return {
+    content: [{ type: 'text', text: response }],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `init_project` MCP tool that sets up glancey in a new project
- Creates or updates CLAUDE.md with comprehensive glancey usage instructions
- Installs post-commit hook to warn when commits bypass the glancey commit tool
- Strengthens SERVER_INSTRUCTIONS with complete tool reference

## Details

### init_project tool
When called, this tool:
1. Creates or updates `CLAUDE.md` with glancey usage instructions (all tools documented)
2. Installs post-commit hook (in `.husky/` if husky is present, otherwise `.git/hooks/`)
3. Returns a summary of what was configured

### Strengthened MCP instructions
Updated `SERVER_INSTRUCTIONS` to include all tool categories:
- Codebase Understanding (summarize_codebase, list_concepts, search_by_concept)
- Semantic Search (search_code, search_similar)
- Symbol Analysis (get_symbols_overview, find_symbol, find_referencing_symbols, search_for_pattern)
- Symbol Editing (replace_symbol_body, insert_before_symbol, insert_after_symbol, rename_symbol)
- Memory (write_memory, read_memory, list_memories, edit_memory, delete_memory)
- Git & Index (commit, index_codebase, get_index_status)
- Worktrees (create_worktree, list_worktrees, worktree_status, remove_worktree)
- Project Setup (init_project)

## Test plan
- [x] All existing tests pass (1286 tests)
- [x] New tests for init-handlers (8 tests)
- [x] Type check passes
- [x] Lint passes (only pre-existing warnings)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)