### PR TITLE
fix: release on all commit types merged to main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,25 @@
 {
-  "branches": [
-    { "name": "main", "channel": "alpha" }
-  ],
+  "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [


### PR DESCRIPTION
## Summary
Updates semantic-release configuration to trigger a patch release on ANY commit type merged to main, not just `feat`/`fix`.

## Changes
- Configured `@semantic-release/commit-analyzer` with custom release rules
- All commit types (`docs`, `chore`, `style`, `refactor`, `test`, `ci`, `build`) now trigger patch releases
- `feat` still triggers minor release, `fix` triggers patch
- Removed alpha channel - releases go to default npm channel

## Why
Ensures every merged PR results in a published version, making it easier to track what's deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)