### PR TITLE
fix: beads toolbar padding and page size

### DIFF
--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -2583,7 +2583,7 @@ export function getDashboardHTML(): string {
     var beadsCurrentView = 'ready';
     var allBeadsIssues = [];
     var beadsCurrentPage = 1;
-    var BEADS_PAGE_SIZE = 20;
+    var BEADS_PAGE_SIZE = 10;
 
     function getBeadsViewIssues() {
       if (beadsCurrentView === 'open') return beadsData.openIssues;


### PR DESCRIPTION
## Summary
- Remove padding from beads toolbar (`#beadsToolbar` padding set to 0)
- Reduce beads pagination page size from 20 to 10

## Test plan
- [ ] Open dashboard and verify beads toolbar has no extra padding
- [ ] Verify pagination shows 10 issues per page