### PR TITLE
feat: add /glancey slash command to init_project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1303,7 +1303,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'init_project',
         description:
-          'Initialize glancey in a project. Creates or updates CLAUDE.md with glancey usage instructions and installs a post-commit hook that warns when commits bypass the glancey commit tool. Run this once when setting up glancey in a new project.',
+          'Initialize glancey in a project. Creates or updates CLAUDE.md with glancey usage instructions, installs a post-commit hook that warns when commits bypass the glancey commit tool, and adds a /glancey slash command for quick reminders. Run this once when setting up glancey in a new project.',
         inputSchema: {
           type: 'object',
           properties: {},


### PR DESCRIPTION
## Summary
- Adds a `/glancey` slash command that gets installed into users' projects when they run `init_project`
- Creates `.claude/commands/glancey.md` with a quick-reference reminder mapping common actions (grep, find, git commit) to their glancey equivalents
- Users can type `/glancey` mid-conversation to nudge the agent back toward using glancey tools

## Test plan
- [ ] Run `init_project` on a test project, verify `.claude/commands/glancey.md` is created
- [ ] Run `init_project` again, verify it skips (idempotent)
- [ ] Verify `/glancey` appears as a slash command in Claude Code
- [ ] Type `/glancey` and confirm the reminder prompt is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)