### PR TITLE
fix: update repo URLs to match Glancey casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/nicholaspsmith/glancey/actions/workflows/ci.yml"><img src="https://github.com/nicholaspsmith/glancey/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/nicholaspsmith/Glancey/actions/workflows/ci.yml"><img src="https://github.com/nicholaspsmith/Glancey/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://www.npmjs.com/package/glancey"><img src="https://img.shields.io/npm/v/glancey.svg" alt="npm version"></a>
-  <a href="https://github.com/nicholaspsmith/glancey/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://github.com/nicholaspsmith/Glancey/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg" alt="Node.js version">
 </p>
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nicholaspsmith/glancey.git"
+    "url": "git+https://github.com/nicholaspsmith/Glancey.git"
   },
   "keywords": [
     "mcp",
@@ -45,9 +45,9 @@
   "author": "Nicholas Smith",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nicholaspsmith/glancey/issues"
+    "url": "https://github.com/nicholaspsmith/Glancey/issues"
   },
-  "homepage": "https://github.com/nicholaspsmith/glancey#readme",
+  "homepage": "https://github.com/nicholaspsmith/Glancey#readme",
   "dependencies": {
     "@lancedb/lancedb": "^0.22.3",
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- Updates repository URLs in `package.json` and `README.md` from lowercase `glancey` to `Glancey` to match the renamed repository
- Fixes the Release workflow failure where semantic-release was pushing to the old lowercase URL, causing branch protection to reject the push

## Test plan
- [ ] CI passes
- [ ] After merge, Release workflow successfully pushes the release commit to main