### PR TITLE
fix: eliminate 30-second startup hang in MCP server

### DIFF
--- a/src/embeddings/ollama.ts
+++ b/src/embeddings/ollama.ts
@@ -49,7 +49,11 @@ export class OllamaBackend implements EmbeddingBackend {
   async initialize(): Promise<void> {
     // Test connection and check if model is available
     try {
-      const response = await fetchWithRetry(`${this.baseUrl}/api/tags`, {});
+      const response = await fetchWithRetry(
+        `${this.baseUrl}/api/tags`,
+        {},
+        { maxRetries: 0, timeoutMs: 5000 }
+      );
       if (!response.ok) {
         throw new Error(`Ollama server returned ${response.status}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2291,6 +2291,11 @@ async function main() {
     process.exit(0);
   }
 
+  // Connect MCP transport immediately so Claude Code doesn't block waiting for us
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('[glancey] MCP server started');
+
   // Disable Serena plugin (glancey replaces it)
   await disableSerena();
 
@@ -2380,10 +2385,6 @@ async function main() {
   } else {
     console.error('[glancey] Dashboard disabled in config');
   }
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('[glancey] MCP server started');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move MCP transport connect to before heavy initialization so Claude Code gets a responsive connection immediately
- Disable retries on backend health checks during startup (Ollama `ECONNREFUSED` was causing ~31s of exponential backoff)
- Replace Gemini `this.embed('test')` with direct fetch using no retries and 5s timeout

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (1294 tests)
- [ ] Manual: restart Claude Code and verify Glancey connects instantly